### PR TITLE
config: add support for "includes"

### DIFF
--- a/doc/ideas.md
+++ b/doc/ideas.md
@@ -1,26 +1,5 @@
 # Ideas, New Features, Usability Enhancements
 
-- config::reader should stop creating `${TREE_NAME}`, `${GARDEN_ROOT}`,
-  and `${GARDEN_CONFIG_DIR}`.  config.rs should create the NamedVariables.
-
-- Modular/reusable garden.yaml configuration.
-
-- Make it possible to full-on include another garden config file inline
-  into a garden file so that we can reuse variables and commands across
-  garden files.
-
-```yaml
-garden:
-    root: "${GARDEN_CONFIG_DIR}"
-    include:
-      - "${GARDEN_CONFIG_DIR}/etc/garden/commands.yaml"
-      - "${GARDEN_CONFIG_DIR}/etc/garden/variables.yaml"
-```
-
-This reader will have to be changed to first parse the includes in the
-listed order copy their contents into the main configuration.
-This seems like this should be possible to attain through refactoring that
-allows the configuration to be iteratively updated by a config reader.
 ## Grafts (WIP)
 
 Make it possible to graft configuration from one graden file into another.

--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.5.0
+
+**Features**
+
+- [Garden configuration files can now include other configuration files
+  ](https://davvid.github.io/garden/configuration.html#includes) by specifying
+  the additional files to include in the `garden.includes` field.
+  The `includes` feature makes it possible to create modular and reusable garden files.
+  The `trees`, `variables`, `commands`, `groups` and `gardens` defined in the included
+  files are added to the current configuration.
+  ([#7](https://github.com/davvid/garden/pull/7))
+
 ## v0.4.1
 
 **Features**

--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -59,6 +59,24 @@ garden:
   root: ~/src
 ```
 
+## Includes
+
+Garden files can be split apart into several files for modularity and reuse.
+You can use the `garden.includes` list to specify other garden files to include
+into the current garden file.
+
+```yaml
+garden:
+  includes:
+    # Includes are relative to the GARDEN_CONFIG_DIR by default.
+    - variables.yaml
+    # Includes can reference custom and built-in ${variables}.
+    - ${include_dir}/commands.yaml
+
+variables:
+  include_dir: ${GARDEN_ROOT}
+```
+
 
 ## Variables
 

--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -7,17 +7,19 @@ Garden will find `garden.yaml` in current directory or in specific locations
 on the filesystem when unspecified.  Garden searches for `garden.yaml` in the
 following locations. The first one found is used.
 
-    # Relative to the current directory
-    ./garden.yaml
-    ./garden/garden.yaml
-    ./etc/garden/garden.yaml
+```sh
+# Relative to the current directory
+./garden.yaml
+./garden/garden.yaml
+./etc/garden/garden.yaml
 
-    # Relative to $HOME
-    ~/.config/garden/garden.yaml
-    ~/etc/garden/garden.yaml
+# Relative to $HOME
+~/.config/garden/garden.yaml
+~/etc/garden/garden.yaml
 
-    # Global configuration
-    /etc/garden/garden.yaml
+# Global configuration
+/etc/garden/garden.yaml
+```
 
 Use `garden -c|--config <filename>` to specify a garden file and override
 garden's file discovery.
@@ -29,6 +31,7 @@ when showing examples.
 {{#include examples/git-cola/garden.yaml}}
 ```
 
+
 ## Garden Root
 
 The garden root directory is configured in the `garden.root` field.
@@ -37,21 +40,24 @@ This directory is the parent directory in which all trees will be cloned.
 Slashes in tree paths will create new directories on disk as needed.
 `garden.root` defaults to the current directory when unspecified.
 
-
 The built-in `${GARDEN_CONFIG_DIR}` variable can be used to create relocatable
 setups that define a `garden.root` relative to the garden file itself.
 
 To place all trees in a `src` directory sibling to the `garden.yaml` file, the
 following configuration can be used:
 
-    garden:
-      root: ${GARDEN_CONFIG_DIR}/src
+```yaml
+garden:
+  root: ${GARDEN_CONFIG_DIR}/src
+```
 
 To place all trees in a `src` directory in your `$HOME` directory, the
 following configuration can be used:
 
-    garden:
-      root: ~/src
+```yaml
+garden:
+  root: ~/src
+```
 
 
 ## Variables
@@ -59,15 +65,17 @@ following configuration can be used:
 Garden configuration contains a "variables" block that allows defining
 variables that are can be referenced by other garden values.
 
-    variables:
-      flavor: debug
-      user: $ whoami
-      libdir: $ test -e /usr/lib64 && echo lib64 || echo lib
-      nproc: $ nproc
-      prefix: ~/.local
-      py_ver_code: from sys import version_info as v; print("%s.%s" % v[:2])
-      py_ver: $ python -c '${py_ver_code}'
-      py_site: ${libdir}/python${py_ver}/site-packages
+```yaml
+variables:
+  flavor: debug
+  user: $ whoami
+  libdir: $ test -e /usr/lib64 && echo lib64 || echo lib
+  nproc: $ nproc
+  prefix: ~/.local
+  py_ver_code: from sys import version_info as v; print("%s.%s" % v[:2])
+  py_ver: $ python -c '${py_ver_code}'
+  py_site: ${libdir}/python${py_ver}/site-packages
+```
 
 Variables definitions can reference environment variables and other garden
 variables.
@@ -88,11 +96,10 @@ override/replace variables defined in a tree scope.
 Garden automatically defines some built-in variables that can be useful
 when constructing values for variables, commands, and paths.
 
-    GARDEN_CONFIG_DIR   -   directory containing the "garden.yaml" config file
-    GARDEN_ROOT         -   root directory for trees
-    TREE_NAME           -   current tree name
-    TREE_PATH           -   current tree path
-
+* **GARDEN_CONFIG_DIR** -- Directory containing the `garden.yaml` config file.
+* **GARDEN_ROOT** -- Root directory for trees.
+* **TREE_NAME** -- Current tree name.
+* **TREE_PATH** -- Current tree path.
 
 ## Environment Variables
 
@@ -111,10 +118,12 @@ both their name and values.
 
 Values in environment blocks prepend to the named environment variable.
 
-    trees:
-      foo:
-        environment:
-          PATH: ${TREE_PATH}/bin
+```yaml
+trees:
+  foo:
+    environment:
+      PATH: ${TREE_PATH}/bin
+```
 
 The example above prepends the `foo/bin` directory to the colon (`:`)-delimeted `PATH`
 environment variable.
@@ -122,20 +131,24 @@ environment variable.
 Names with an equals sign (`=`) suffix are treated as "store" operations and are
 stored into the environment, fully replacing any pre-existing values.
 
-    trees:
-      foo:
-        environment:
-          ${TREE_NAME}_LOCATION=: ${TREE_PATH}
+```yaml
+trees:
+  foo:
+    environment:
+      ${TREE_NAME}_LOCATION=: ${TREE_PATH}
+```
 
 The example above exports a variable called `foo_LOCATION` with the location of the tree.
 If `foo_LOCATION` is already defined then it its value is replaced.
 
 A plus sign (`+`) suffix in the name append to a variable instead of prepending.
 
-    trees:
-      foo:
-        environment:
-          PATH+: ${TREE_PATH}/bin
+```yaml
+trees:
+  foo:
+    environment:
+      PATH+: ${TREE_PATH}/bin
+```
 
 The example above appends to the `PATH` environment variable.
 Note the `+` suffix after `PATH`.
@@ -229,10 +242,12 @@ matches "cola" only.
 Symlink trees create a symlink on the filesystem during `garden init`.
 `garden exec`, and custom `garden cmd` commands ignore symlink trees.
 
-    trees:
-      media:
-        path: ~/media
-        symlink: /media/${USER}
+```yaml
+trees:
+  media:
+    path: ~/media
+    symlink: /media/${USER}
+```
 
 The "path" entry behaves like the tree "path" entry -- when unspecified it
 defaults to a path named after the tree relative to the garden root.

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -223,5 +223,5 @@ pub fn parse_args(parser: argparse::ArgumentParser, arguments: Vec<String>) {
     parser
         .parse(arguments, &mut std::io::stdout(), &mut std::io::stderr())
         .map_err(std::process::exit)
-        .ok();
+        .unwrap_or(());
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -133,13 +133,12 @@ pub fn new(
     if found {
         // Read file contents.
         let config_path = cfg.get_path()?;
-        let config_string = match std::fs::read_to_string(config_path) {
-            Ok(content) => content,
+        if let Ok(config_string) = std::fs::read_to_string(config_path) {
+            parse(&config_string, config_verbose, &mut cfg)?;
+        } else {
             // Return a default Configuration If we are unable to read the file.
-            Err(_) => return Ok(cfg),
-        };
-
-        parse(&config_string, config_verbose, &mut cfg)?;
+            return Ok(cfg);
+        }
     }
 
     // Default to the current directory when garden.root is unspecified

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -245,7 +245,7 @@ fn get_variables(yaml: &Yaml, vec: &mut Vec<model::NamedVariable>) -> bool {
                             vec.push(model::NamedVariable::new(
                                 key.to_string(),
                                 yaml_str.clone(),
-                                None,
+                                None, // Defer resolution of string values.
                             ));
                         }
                     }
@@ -255,7 +255,7 @@ fn get_variables(yaml: &Yaml, vec: &mut Vec<model::NamedVariable>) -> bool {
                     vec.push(model::NamedVariable::new(
                         key,
                         value.clone(),
-                        Some(value.clone()),
+                        Some(value.clone()), // Integer values are already resolved.
                     ));
                 }
                 Yaml::Boolean(ref yaml_bool) => {
@@ -263,7 +263,7 @@ fn get_variables(yaml: &Yaml, vec: &mut Vec<model::NamedVariable>) -> bool {
                     vec.push(model::NamedVariable::new(
                         key,
                         value.clone(),
-                        Some(value.clone()),
+                        Some(value.clone()), // Booleans are already resolved.
                     ));
                 }
                 _ => {

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -787,7 +787,7 @@ fn add_missing_sections(doc: &mut Yaml) -> Result<(), errors::GardenError> {
 
 pub fn empty_doc() -> Yaml {
     let mut doc = Yaml::Hash(YamlHash::new());
-    add_missing_sections(&mut doc).ok();
+    add_missing_sections(&mut doc).unwrap_or(());
 
     doc
 }

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -217,6 +217,25 @@ fn get_vec_str(yaml: &Yaml, vec: &mut Vec<String>) -> bool {
     false
 }
 
+/// Yaml::String or Yaml::Array<Yaml::String> -> Vec<Variable>
+fn get_vec_variables(yaml: &Yaml, vec: &mut Vec<model::Variable>) -> bool {
+    if let Yaml::String(yaml_string) = yaml {
+        vec.push(model::Variable::new(yaml_string.clone(), None));
+        return true;
+    }
+
+    if let Yaml::Array(ref yaml_vec) = yaml {
+        for value in yaml_vec {
+            if let Yaml::String(ref value_str) = value {
+                vec.push(model::Variable::new(value_str.clone(), None));
+            }
+        }
+        return true;
+    }
+
+    false
+}
+
 // Yaml::String -> Variable
 fn get_variable(yaml: &Yaml, value: &mut model::Variable) -> bool {
     let mut result = false;

--- a/src/config/writer.rs
+++ b/src/config/writer.rs
@@ -16,7 +16,7 @@ where
     {
         let mut emitter = YamlEmitter::new(&mut out_str);
         emitter.multiline_strings(true);
-        emitter.dump(doc).ok(); // dump the YAML object to a String
+        emitter.dump(doc).unwrap_or(()); // dump the YAML object to a String
     }
     out_str += "\n";
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -606,17 +606,27 @@ impl Configuration {
         self.tree_path(&value)
     }
 
-    /// Resolve a path string relative to the config dir.
-    pub fn config_path(&self, path: &str) -> String {
-        if std::path::PathBuf::from(path).is_absolute() {
+    /// Resolve a pathbuf relative to the config dir.
+    pub fn config_pathbuf(&self, path: &str) -> Option<std::path::PathBuf> {
+        let mut path_buf = std::path::PathBuf::from(path);
+        if path_buf.is_absolute() {
             // Absolute path, nothing to do
-            path.into()
+            Some(path_buf)
         } else if let Some(dirname) = self.dirname.as_ref() {
             // Make path relative to the configuration's dirname
-            let mut path_buf = dirname.to_path_buf();
+            path_buf = dirname.to_path_buf();
             path_buf.push(path);
 
-            path_buf.to_string_lossy().into()
+            Some(path_buf)
+        } else {
+            None
+        }
+    }
+
+    /// Resolve a path string relative to the config dir.
+    pub fn config_path(&self, path: &str) -> String {
+        if let Some(path_buf) = self.config_pathbuf(path) {
+            path_buf.to_string_lossy().to_string()
         } else {
             self.tree_path(path)
         }
@@ -626,6 +636,12 @@ impl Configuration {
     pub fn eval_config_path(&self, path: &str) -> String {
         let value = eval::value(self, path);
         self.config_path(&value)
+    }
+
+    /// Evaluate and resolve a pathbuf relative to the config dir.
+    pub fn eval_config_pathbuf(&self, path: &str) -> Option<std::path::PathBuf> {
+        let value = eval::value(self, path);
+        self.config_pathbuf(&value)
     }
 
     /// Reset resolved variables

--- a/src/model.rs
+++ b/src/model.rs
@@ -625,7 +625,6 @@ impl Configuration {
     /// Evaluate and resolve a path string and relative to the config dir.
     pub fn eval_config_path(&self, path: &str) -> String {
         let value = eval::value(self, path);
-
         self.config_path(&value)
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -20,7 +20,7 @@ pub fn from_string(string: &str) -> model::Configuration {
     initialize_environment();
 
     let mut config = model::Configuration::new();
-    config::parse(string, 0, &mut config).ok();
+    config::parse(string, 0, &mut config).unwrap_or(());
 
     config
 }

--- a/tests/data/garden.yaml
+++ b/tests/data/garden.yaml
@@ -1,27 +1,9 @@
 ---
-grafts:
-  graft: grafts/graft.yaml
-  libs:
-    config: grafts/libs.yaml
-    root: libs
 
 variables:
   current_config: main
   gh_ssh: "git@github.com"
   repos: ${GARDEN_ROOT}/repos
-
-gardens:
-  dev:
-    groups:
-      - libs::core
-      - graft::core
-    trees:
-      - graft::graft
-      - example/tree
-  graft_garden:
-    trees:
-      - graft::graft
-      - graft::core
 
 trees:
   # repos/example.git is created by setup.sh during the integration test.
@@ -92,3 +74,26 @@ commands:
   - "false"
   - echo after error
   - "false"
+
+gardens:
+  # WIP(grafts)
+  dev:
+    groups:
+      - libs::core
+      - graft::core
+    trees:
+      - graft::graft
+      - example/tree
+  graft_garden:
+    trees:
+      - graft::graft
+      - graft::core
+
+# WIP(grafts): grafts are not yet implemented. If implemented, the "grafts" block
+# will provide the namespaced "graft::*" and "libs::*" trees and variables that
+# can then be referenced within this file.
+grafts:
+  graft: grafts/graft.yaml
+  libs:
+    config: grafts/libs.yaml
+    root: libs

--- a/tests/data/garden.yaml
+++ b/tests/data/garden.yaml
@@ -1,9 +1,18 @@
 ---
+garden:
+  includes:
+    # Paths are implicitly relative to ${GARDEN_CONFIG_DIR}.
+    - variables.yaml
+    # # Paths can use ${variables} defined in the current config file.
+    - trees.yaml
+    # # Includes are recursive.
+    - includes.yaml
 
 variables:
   current_config: main
   gh_ssh: "git@github.com"
   repos: ${GARDEN_ROOT}/repos
+  config_dir: ${GARDEN_CONFIG_DIR}
 
 trees:
   # repos/example.git is created by setup.sh during the integration test.

--- a/tests/data/includes.yaml
+++ b/tests/data/includes.yaml
@@ -1,0 +1,7 @@
+---
+garden:
+  includes: variables-transitive.yaml
+
+variables:
+  var_1: ONE
+...

--- a/tests/data/trees.yaml
+++ b/tests/data/trees.yaml
@@ -1,0 +1,5 @@
+---
+trees:
+  tree-zero:
+    path: tree_0
+...

--- a/tests/data/variables-transitive.yaml
+++ b/tests/data/variables-transitive.yaml
@@ -1,0 +1,5 @@
+---
+variables:
+  var_1: one
+  var_2: two
+...

--- a/tests/data/variables.yaml
+++ b/tests/data/variables.yaml
@@ -1,0 +1,4 @@
+---
+variables:
+  var_0: zero
+...

--- a/tests/includes_test.rs
+++ b/tests/includes_test.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+
+#[test]
+fn read_includes() -> Result<()> {
+    let options = garden::model::CommandOptions::new();
+    let app = garden::build::context_from_path("tests/data/garden.yaml", options)?;
+    let config = app.get_root_config();
+
+    // var_0 is from the included variables.yaml..
+    let actual = garden::eval::value(&config, "${var_0}");
+    assert_eq!(actual, "zero");
+    // var_1 is provided by variables-transitive.yaml and overridden by includes.yaml.
+    let actual = garden::eval::value(&config, "${var_1}");
+    assert_eq!(actual, "ONE");
+    // var_2 is provided by variables-transitive.yaml.
+    let actual = garden::eval::value(&config, "${var_2}");
+    assert_eq!(actual, "two");
+
+    // Trees are provided by included configs.
+    assert!(config.trees.len() >= 2);
+    // trees[0] is included from trees.yaml.
+    assert_eq!(config.trees[0].get_name(), "tree-zero");
+    // trees[1] is from the main config.
+    assert_eq!(config.trees[1].get_name(), "example/tree");
+
+    Ok(())
+}


### PR DESCRIPTION
Teach the config reader to process `garden.includes` for including additional garden files into the current configuration.

The `includes` feature makes it possible to create modular and reusable garden files.
