### PR TITLE
eval: add ability to evaluate environment blocks from variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ checksum = "673464e1e314dd67a0fd9544abc99e8eb28d0c7e3b69b033bcff9b2d00b87333"
 
 [[package]]
 name = "garden-tools"
-version = "1.2.1"
+version = "1.3.0-beta0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "garden-tools"
-version = "1.2.1"
+version = "1.3.0-beta0"
 edition = "2021"
 description = """
 Garden grows and cultivates collections of Git trees

--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -1,6 +1,24 @@
 # Changelog
 
+## v1.3.0
+
+**Features**:
+
+- `garden eval` and garden expressions in general will now resolve variables defined
+  within `environment` blocks. Environment blocks were previously not considered when
+  resolving variables. Environment blocks are now resolved and checked for variables
+  when `${variable}` expressions do not find the variable in scopes with higher
+  precedence. The precedence order, from strongest to weakest, is the `variables`
+  block in a garden's scope, the `variables` block in a tree's scope, the
+  `variables` block in global configuration scope, the `environments` block in
+  a garden's scope, the `environments` block in a tree's scope, the
+  `environments` block in global configuration scope and, lastly, OS environment
+  variables. The first entry found is used when expanding variable expressions.
+
+
 ## v1.2.1
+
+*Released 2023-02-05*
 
 **Development**:
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -121,7 +121,21 @@ where
     S: AsRef<std::ffi::OsStr>,
 {
     let path;
-    if let Some(tree) = config.trees.get(&context.tree) {
+    let graft_config = context
+        .graft_config
+        .map(|graft_id| app_context.get_config(graft_id));
+    if let Some(graft_cfg) = graft_config {
+        if let Some(tree) = graft_cfg.trees.get(&context.tree) {
+            path = tree.path_as_ref()?;
+
+            // Sparse gardens/missing trees are okay -> skip these entries.
+            if !display::print_tree(tree, config.tree_branches, verbose, quiet) {
+                return Ok(());
+            }
+        } else {
+            return Ok(());
+        }
+    } else if let Some(tree) = config.trees.get(&context.tree) {
         path = tree.path_as_ref()?;
 
         // Sparse gardens/missing trees are okay -> skip these entries.

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -122,7 +122,7 @@ where
 {
     let path;
     let graft_config = context
-        .graft_config
+        .config
         .map(|graft_id| app_context.get_config(graft_id));
     if let Some(graft_cfg) = graft_config {
         if let Some(tree) = graft_cfg.trees.get(&context.tree) {

--- a/src/cmds/cmd.rs
+++ b/src/cmds/cmd.rs
@@ -188,7 +188,7 @@ pub fn main_custom(app_context: &model::ApplicationContext, arguments: &Vec<Stri
 
 fn cmd(app_context: &model::ApplicationContext, query: &str, params: &CmdParams) -> Result<i32> {
     let config = app_context.get_root_config_mut();
-    let contexts = query::resolve_trees(app_context, config, query);
+    let contexts = query::resolve_trees(app_context, config, None, query);
     if params.breadth_first {
         run_cmd_breadth_first(app_context, &contexts, params)
     } else {

--- a/src/cmds/eval.rs
+++ b/src/cmds/eval.rs
@@ -29,15 +29,15 @@ pub fn main(app_context: &model::ApplicationContext, eval: &EvalOptions) -> Resu
             // Evaluate and print the garden expression.
             let garden = eval.garden.as_deref();
             let ctx = query::find_tree(app_context, app_context.get_root_id(), tree, garden)?;
-            let config = match ctx.config {
-                Some(config_id) => app_context.get_config(config_id),
-                None => app_context.get_root_config(),
-            };
+            let graft_config = ctx
+                .graft_config
+                .map(|graft_id| app_context.get_config(graft_id));
             let value = eval::tree_value(
                 app_context,
-                config,
-                eval.expr.as_str(),
-                ctx.tree.as_str(),
+                app_context.get_root_config(),
+                graft_config,
+                &eval.expr,
+                &ctx.tree,
                 ctx.garden.as_ref(),
             );
             println!("{value}");

--- a/src/cmds/eval.rs
+++ b/src/cmds/eval.rs
@@ -29,9 +29,7 @@ pub fn main(app_context: &model::ApplicationContext, eval: &EvalOptions) -> Resu
             // Evaluate and print the garden expression.
             let garden = eval.garden.as_deref();
             let ctx = query::find_tree(app_context, app_context.get_root_id(), tree, garden)?;
-            let graft_config = ctx
-                .graft_config
-                .map(|graft_id| app_context.get_config(graft_id));
+            let graft_config = ctx.config.map(|graft_id| app_context.get_config(graft_id));
             let value = eval::tree_value(
                 app_context,
                 app_context.get_root_config(),

--- a/src/cmds/eval.rs
+++ b/src/cmds/eval.rs
@@ -22,7 +22,8 @@ pub fn main(app_context: &model::ApplicationContext, eval: &EvalOptions) -> Resu
             // Evaluate and print the expression in global scope. No trees or gardens
             // were provided so only the top-level variables are included.
             let config = app_context.get_root_config();
-            println!("{}", eval::value(app_context, config, &eval.expr));
+            let value = eval::value(app_context, config, &eval.expr);
+            println!("{value}");
         }
         Some(tree) => {
             // Evaluate and print the garden expression.

--- a/src/cmds/exec.rs
+++ b/src/cmds/exec.rs
@@ -65,7 +65,7 @@ fn exec(
         if !pattern.matches(&context.tree) {
             continue;
         }
-        let tree_opt = match context.graft_config {
+        let tree_opt = match context.config {
             Some(graft_id) => app_context.get_config(graft_id).trees.get(&context.tree),
             None => config.trees.get(&context.tree),
         };

--- a/src/cmds/exec.rs
+++ b/src/cmds/exec.rs
@@ -55,7 +55,7 @@ fn exec(
     // with no garden context.
 
     // Resolve the tree query into a vector of tree contexts.
-    let contexts = query::resolve_trees(app_context, config, query);
+    let contexts = query::resolve_trees(app_context, config, None, query);
     let pattern = glob::Pattern::new(tree_pattern).unwrap_or_default();
     let mut exit_status: i32 = 0;
 
@@ -65,11 +65,11 @@ fn exec(
         if !pattern.matches(&context.tree) {
             continue;
         }
-        let config = match context.config {
-            Some(config_id) => app_context.get_config(config_id),
-            None => config,
+        let tree_opt = match context.graft_config {
+            Some(graft_id) => app_context.get_config(graft_id).trees.get(&context.tree),
+            None => config.trees.get(&context.tree),
         };
-        let tree = match config.trees.get(&context.tree) {
+        let tree = match tree_opt {
             Some(tree) => tree,
             None => continue,
         };

--- a/src/cmds/grow.rs
+++ b/src/cmds/grow.rs
@@ -79,14 +79,22 @@ fn grow_tree_from_context(
     quiet: bool,
     verbose: u8,
 ) -> Result<i32> {
-    let config = match context.config {
-        Some(config_id) => app_context.get_config(config_id),
-        None => app_context.get_root_config(),
-    };
+    let config = app_context.get_root_config();
+    let graft_config = context
+        .config
+        .map(|config_id| app_context.get_config(config_id));
     let mut exit_status = errors::EX_OK;
-    let tree = match config.trees.get(&context.tree) {
-        Some(tree) => tree,
-        None => return Ok(exit_status),
+
+    let tree = if let Some(graft_cfg) = graft_config {
+        match graft_cfg.trees.get(&context.tree) {
+            Some(tree) => tree,
+            None => return Ok(exit_status),
+        }
+    } else {
+        match config.trees.get(&context.tree) {
+            Some(tree) => tree,
+            None => return Ok(exit_status),
+        }
     };
 
     let path = tree.path_as_ref()?.clone();
@@ -134,6 +142,7 @@ fn grow_tree_from_context(
         Some(remote) => eval::tree_value(
             app_context,
             config,
+            graft_config,
             remote.get_expr(),
             &context.tree,
             context.garden.as_ref(),
@@ -161,6 +170,7 @@ fn grow_tree_from_context(
     let branch = eval::tree_value(
         app_context,
         config,
+        graft_config,
         tree.branch.get_expr(),
         &context.tree,
         context.garden.as_ref(),
@@ -245,14 +255,22 @@ fn update_tree_from_context(
     _quiet: bool,
     verbose: u8,
 ) -> Result<i32> {
-    let config = match ctx.config {
-        Some(config_id) => app_context.get_config(config_id),
-        None => app_context.get_root_config(),
-    };
+    let config = app_context.get_root_config();
+    let graft_config = ctx
+        .config
+        .map(|config_id| app_context.get_config(config_id));
     let mut exit_status = errors::EX_OK;
-    let tree = match config.trees.get(&ctx.tree) {
-        Some(tree) => tree,
-        None => return Ok(exit_status),
+
+    let tree = if let Some(graft_cfg) = graft_config {
+        match graft_cfg.trees.get(&ctx.tree) {
+            Some(tree) => tree,
+            None => return Ok(exit_status),
+        }
+    } else {
+        match config.trees.get(&ctx.tree) {
+            Some(tree) => tree,
+            None => return Ok(exit_status),
+        }
     };
 
     // Existing symlinks require no further processing.
@@ -290,6 +308,7 @@ fn update_tree_from_context(
         let url = eval::tree_value(
             app_context,
             config,
+            graft_config,
             var.get_expr(),
             &ctx.tree,
             ctx.garden.as_ref(),
@@ -337,6 +356,7 @@ fn update_tree_from_context(
         let name = eval::tree_value(
             app_context,
             config,
+            graft_config,
             var_name,
             &ctx.tree,
             ctx.garden.as_ref(),
@@ -347,6 +367,7 @@ fn update_tree_from_context(
                 None => eval::tree_value(
                     app_context,
                     config,
+                    graft_config,
                     var.get_expr(),
                     &ctx.tree,
                     ctx.garden.as_ref(),
@@ -457,18 +478,28 @@ fn grow_tree_from_context_as_worktree(
     quiet: bool,
     verbose: u8,
 ) -> Result<i32> {
-    let config = match ctx.config {
-        Some(config_id) => app_context.get_config(config_id),
-        None => app_context.get_root_config(),
-    };
+    let config = app_context.get_root_config();
+    let graft_config = ctx
+        .config
+        .map(|config_id| app_context.get_config(config_id));
     let mut exit_status = errors::EX_OK;
-    let tree = match config.trees.get(&ctx.tree) {
-        Some(tree) => tree,
-        None => return Ok(exit_status),
+
+    let tree = if let Some(graft_cfg) = graft_config {
+        match graft_cfg.trees.get(&ctx.tree) {
+            Some(tree) => tree,
+            None => return Ok(exit_status),
+        }
+    } else {
+        match config.trees.get(&ctx.tree) {
+            Some(tree) => tree,
+            None => return Ok(exit_status),
+        }
     };
+
     let worktree = eval::tree_value(
         app_context,
         config,
+        graft_config,
         tree.worktree.get_expr(),
         &ctx.tree,
         ctx.garden.as_ref(),
@@ -476,6 +507,7 @@ fn grow_tree_from_context_as_worktree(
     let branch = eval::tree_value(
         app_context,
         config,
+        graft_config,
         tree.branch.get_expr(),
         &ctx.tree,
         ctx.garden.as_ref(),

--- a/src/cmds/shell.rs
+++ b/src/cmds/shell.rs
@@ -20,7 +20,7 @@ pub fn main(app_context: &model::ApplicationContext, options: &ShellOptions) -> 
         return Err(errors::GardenError::EmptyTreeQueryResult(options.query.clone()).into());
     }
     let mut context = contexts[0].clone();
-    let graft_config = context.graft_config.map(|id| app_context.get_config(id));
+    let graft_config = context.config.map(|id| app_context.get_config(id));
 
     // If a tree's name in the returned contexts exactly matches the tree
     // query that was used to find it then chdir into that tree.

--- a/src/cmds/shell.rs
+++ b/src/cmds/shell.rs
@@ -20,7 +20,6 @@ pub fn main(app_context: &model::ApplicationContext, options: &ShellOptions) -> 
         return Err(errors::GardenError::EmptyTreeQueryResult(options.query.clone()).into());
     }
     let mut context = contexts[0].clone();
-    let graft_config = context.config.map(|id| app_context.get_config(id));
 
     // If a tree's name in the returned contexts exactly matches the tree
     // query that was used to find it then chdir into that tree.
@@ -54,6 +53,7 @@ pub fn main(app_context: &model::ApplicationContext, options: &ShellOptions) -> 
     }
 
     // Evaluate garden.shell
+    let graft_config = context.config.map(|id| app_context.get_config(id));
     let shell_expr = config.shell.clone();
     let shell = eval::tree_value(
         app_context,

--- a/src/cmds/shell.rs
+++ b/src/cmds/shell.rs
@@ -15,11 +15,12 @@ pub struct ShellOptions {
 
 pub fn main(app_context: &model::ApplicationContext, options: &ShellOptions) -> Result<()> {
     let config = app_context.get_root_config_mut();
-    let contexts = query::resolve_trees(app_context, config, &options.query);
+    let contexts = query::resolve_trees(app_context, config, None, &options.query);
     if contexts.is_empty() {
         return Err(errors::GardenError::EmptyTreeQueryResult(options.query.clone()).into());
     }
     let mut context = contexts[0].clone();
+    let graft_config = context.graft_config.map(|id| app_context.get_config(id));
 
     // If a tree's name in the returned contexts exactly matches the tree
     // query that was used to find it then chdir into that tree.
@@ -57,6 +58,7 @@ pub fn main(app_context: &model::ApplicationContext, options: &ShellOptions) -> 
     let shell = eval::tree_value(
         app_context,
         config,
+        graft_config,
         &shell_expr,
         &context.tree,
         context.garden.as_ref(),

--- a/src/display.rs
+++ b/src/display.rs
@@ -180,6 +180,7 @@ pub(crate) fn print_tree_extended_details(
             let value = eval::tree_value(
                 app_context,
                 config,
+                None,
                 remote.get_expr(),
                 &context.tree,
                 context.garden.as_ref(),
@@ -198,6 +199,7 @@ pub(crate) fn print_tree_extended_details(
             let value = eval::tree_value(
                 app_context,
                 config,
+                None,
                 link.get_expr(),
                 &context.tree,
                 context.garden.as_ref(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -666,7 +666,6 @@ impl Configuration {
     pub(crate) fn reset(&mut self) {
         // Reset variables to allow for tree-scope evaluation
         self.reset_variables();
-
         // Add custom variables
         self.reset_builtin_variables()
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1056,6 +1056,7 @@ pub struct TreeContext {
     pub config: Option<ConfigId>,
     pub garden: Option<GardenName>,
     pub group: Option<String>,
+    pub graft_config: Option<ConfigId>,
 }
 
 impl_display_brief!(TreeContext);
@@ -1067,12 +1068,14 @@ impl TreeContext {
         config: Option<ConfigId>,
         garden: Option<GardenName>,
         group: Option<String>,
+        graft_config: Option<ConfigId>,
     ) -> Self {
         TreeContext {
             tree: TreeName::from(tree),
             config,
             garden,
             group,
+            graft_config,
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -546,6 +546,11 @@ impl Configuration {
         self.reset();
     }
 
+    /// Return Some(&NodeId) when the configuration is a graft and None otherwise.
+    pub(crate) fn graft_id(&self) -> Option<NodeId> {
+        self.parent_id.and(self.get_id())
+    }
+
     pub(crate) fn update(
         &mut self,
         app_context: &ApplicationContext,
@@ -1056,7 +1061,6 @@ pub struct TreeContext {
     pub config: Option<ConfigId>,
     pub garden: Option<GardenName>,
     pub group: Option<String>,
-    pub graft_config: Option<ConfigId>,
 }
 
 impl_display_brief!(TreeContext);
@@ -1068,14 +1072,12 @@ impl TreeContext {
         config: Option<ConfigId>,
         garden: Option<GardenName>,
         group: Option<String>,
-        graft_config: Option<ConfigId>,
     ) -> Self {
         TreeContext {
             tree: TreeName::from(tree),
             config,
             garden,
             group,
-            graft_config,
         }
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -427,10 +427,10 @@ pub fn tree_context(
             });
         }
 
+        ctx.garden = garden.map(|value| value.to_string());
         let mut found = false;
         for current_ctx in &contexts {
             if current_ctx.tree == ctx.tree {
-                ctx.garden = current_ctx.garden.clone();
                 found = true;
                 break;
             }

--- a/src/query.rs
+++ b/src/query.rs
@@ -412,8 +412,15 @@ pub fn tree_context(
                 garden: garden_name.into(),
             }
         })?;
-        let contexts = garden_trees(app_context, config, &pattern);
-
+        let mut contexts = garden_trees(app_context, config, &pattern);
+        if contexts.is_empty() {
+            // The current config may be a graft. Allow finding grafts from parents.
+            if let Some(parent_id) = config.parent_id {
+                let parent_config = app_context.get_config(parent_id);
+                contexts = garden_trees(app_context, parent_config, &pattern);
+                ctx.config = parent_config.get_id();
+            }
+        }
         if contexts.is_empty() {
             return Err(errors::GardenError::GardenNotFound {
                 garden: garden_name.to_string(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -11,6 +11,7 @@ use crate::{constants, errors, eval, model, path, query, syntax};
 pub fn resolve_trees(
     app_context: &model::ApplicationContext,
     config: &model::Configuration,
+    graft_config: Option<&model::Configuration>,
     query: &str,
 ) -> Vec<model::TreeContext> {
     let mut result = Vec::new();
@@ -18,23 +19,49 @@ pub fn resolve_trees(
     let pattern = &tree_query.pattern;
 
     if tree_query.include_gardens {
-        result = garden_trees(app_context, config, pattern);
+        result = garden_trees(app_context, config, graft_config, pattern);
         if !result.is_empty() {
             return result;
         }
     }
 
+    let mut group_found = false;
     if tree_query.include_groups {
-        for (name, group) in &config.groups {
-            // Find the matching group
-            if !pattern.matches(name) {
-                continue;
+        if let Some(graft_cfg) = graft_config {
+            for (name, group) in &graft_cfg.groups {
+                // Find the matching group
+                if !pattern.matches(name) {
+                    continue;
+                }
+                // Matching group found, collect its trees
+                result.append(&mut trees_from_group(
+                    app_context,
+                    config,
+                    graft_config,
+                    None,
+                    group,
+                ));
+                group_found = true;
             }
-            // Matching group found, collect its trees
-            result.append(&mut trees_from_group(app_context, config, None, group));
         }
-        if !result.is_empty() {
-            return result;
+        if !group_found {
+            for (name, group) in &config.groups {
+                // Find the matching group
+                if !pattern.matches(name) {
+                    continue;
+                }
+                // Matching group found, collect its trees
+                result.append(&mut trees_from_group(
+                    app_context,
+                    config,
+                    graft_config,
+                    None,
+                    group,
+                ));
+            }
+            if !result.is_empty() {
+                return result;
+            }
         }
     }
 
@@ -45,10 +72,13 @@ pub fn resolve_trees(
             if let Ok((graft_id, remainder)) = config.get_graft_id(query) {
                 result.append(&mut resolve_trees(
                     app_context,
-                    app_context.get_config(graft_id),
+                    config,
+                    Some(app_context.get_config(graft_id)),
                     remainder,
                 ));
             }
+        } else if let Some(graft_cfg) = graft_config {
+            result.append(&mut trees(graft_cfg, pattern));
         } else {
             result.append(&mut trees(config, pattern));
         }
@@ -84,7 +114,7 @@ pub(crate) fn resolve_and_filter_trees(
     query: &str,
     pattern: &str,
 ) -> Vec<model::TreeContext> {
-    let contexts = resolve_trees(app_context, config, query);
+    let contexts = resolve_trees(app_context, config, None, query);
     let tree_pattern = glob::Pattern::new(pattern).unwrap_or_default();
     let mut result = Vec::with_capacity(contexts.len());
     for context in contexts {
@@ -104,15 +134,37 @@ pub(crate) fn resolve_and_filter_trees(
 fn garden_trees(
     app_context: &model::ApplicationContext,
     config: &model::Configuration,
+    graft_config: Option<&model::Configuration>,
     pattern: &glob::Pattern,
 ) -> Vec<model::TreeContext> {
     let mut result = Vec::new();
-
-    for (name, garden) in &config.gardens {
-        if !pattern.matches(name) {
-            continue;
+    let mut garden_found = false;
+    if let Some(graft_cfg) = graft_config {
+        for (name, garden) in &graft_cfg.gardens {
+            if !pattern.matches(name) {
+                continue;
+            }
+            result.append(&mut trees_from_garden(
+                app_context,
+                config,
+                graft_config,
+                garden,
+            ));
+            garden_found = true;
         }
-        result.append(&mut trees_from_garden(app_context, config, garden));
+    }
+    if !garden_found {
+        for (name, garden) in &config.gardens {
+            if !pattern.matches(name) {
+                continue;
+            }
+            result.append(&mut trees_from_garden(
+                app_context,
+                config,
+                graft_config,
+                garden,
+            ));
+        }
     }
 
     result
@@ -122,6 +174,7 @@ fn garden_trees(
 pub fn trees_from_garden(
     app_context: &model::ApplicationContext,
     config: &model::Configuration,
+    graft_config: Option<&model::Configuration>,
     garden: &model::Garden,
 ) -> Vec<model::TreeContext> {
     let mut result = Vec::new();
@@ -134,7 +187,11 @@ pub fn trees_from_garden(
             Err(_) => continue,
         };
         // Loop over configured groups to find the matching groups
-        for (name, cfg_group) in &config.groups {
+        let config_groups = match graft_config {
+            Some(graft_cfg) => &graft_cfg.groups,
+            None => &config.groups,
+        };
+        for (name, cfg_group) in config_groups {
             if !pattern.matches(name) {
                 continue;
             }
@@ -142,6 +199,7 @@ pub fn trees_from_garden(
             result.append(&mut trees_from_group(
                 app_context,
                 config,
+                graft_config,
                 Some(garden.get_name()),
                 cfg_group,
             ));
@@ -153,6 +211,7 @@ pub fn trees_from_garden(
         result.append(&mut trees_from_pattern(
             app_context,
             config,
+            graft_config,
             tree,
             Some(garden.get_name()),
             None,
@@ -166,16 +225,16 @@ pub fn trees_from_garden(
 pub fn trees_from_group(
     app_context: &model::ApplicationContext,
     config: &model::Configuration,
+    graft_config: Option<&model::Configuration>,
     garden: Option<&model::GardenName>,
     group: &model::Group,
 ) -> Vec<model::TreeContext> {
     let mut result = Vec::new();
-
-    // Collect indexes for each tree in this group
     for tree in &group.members {
         result.append(&mut trees_from_pattern(
             app_context,
             config,
+            graft_config,
             tree,
             garden,
             Some(group.get_name()),
@@ -205,6 +264,7 @@ pub fn tree_from_name(
             config.get_id(),
             garden_name.cloned(),
             group.cloned(),
+            None,
         ));
     }
 
@@ -227,6 +287,7 @@ pub fn tree_from_name(
 pub fn trees_from_pattern(
     app_context: &model::ApplicationContext,
     config: &model::Configuration,
+    graft_config: Option<&model::Configuration>,
     tree: &str,
     garden_name: Option<&model::GardenName>,
     group: Option<&model::GroupName>,
@@ -236,7 +297,8 @@ pub fn trees_from_pattern(
         if let Ok((graft_id, remainder)) = config.get_graft_id(tree) {
             return trees_from_pattern(
                 app_context,
-                app_context.get_config(graft_id),
+                config,
+                Some(app_context.get_config(graft_id)),
                 remainder,
                 garden_name,
                 group,
@@ -250,6 +312,21 @@ pub fn trees_from_pattern(
         Ok(value) => value,
         Err(_) => return result,
     };
+
+    if let Some(graft_cfg) = graft_config {
+        for (tree_name, cfg_tree) in &graft_cfg.trees {
+            if pattern.matches(tree_name) {
+                // Tree found in a grafted configuration.
+                result.push(model::TreeContext::new(
+                    cfg_tree.get_name(),
+                    config.get_id(),
+                    garden_name.cloned(),
+                    group.cloned(),
+                    graft_cfg.get_id(),
+                ));
+            }
+        }
+    }
     for (tree_name, cfg_tree) in &config.trees {
         if pattern.matches(tree_name) {
             // Tree found in a grafted configuration.
@@ -258,6 +335,7 @@ pub fn trees_from_pattern(
                 config.get_id(),
                 garden_name.cloned(),
                 group.cloned(),
+                None,
             ));
         }
     }
@@ -302,7 +380,13 @@ fn tree_from_pathbuf(
             Err(_) => continue,
         };
         if pathbuf == tree_canon {
-            return Some(model::TreeContext::new(name, config.get_id(), None, None));
+            return Some(model::TreeContext::new(
+                name,
+                config.get_id(),
+                None,
+                None,
+                None,
+            ));
         }
     }
 
@@ -326,7 +410,13 @@ fn tree_from_pathbuf(
                     Err(_) => continue,
                 };
                 if dirname == &tree_canon {
-                    return Some(model::TreeContext::new(name, config.get_id(), None, None));
+                    return Some(model::TreeContext::new(
+                        name,
+                        config.get_id(),
+                        None,
+                        None,
+                        None,
+                    ));
                 }
             }
         }
@@ -384,6 +474,7 @@ fn trees(config: &model::Configuration, pattern: &glob::Pattern) -> Vec<model::T
                 config.get_id(),
                 None,
                 None,
+                None,
             ));
         }
     }
@@ -405,6 +496,13 @@ pub fn tree_context(
             tree: tree.to_string(),
         }
     })?;
+    // If current configuration is a graft then reset the context to the root configuration
+    // and record the graft so that later lookups use the graft's context.
+    // This is effectively the inverse of the recursive deepening performed by find_tree().
+    if config.parent_id.is_some() {
+        ctx.config = app_context.get_root_config().get_id();
+        ctx.graft_config = config.get_id();
+    }
 
     if let Some(garden_name) = garden {
         let pattern = glob::Pattern::new(garden_name).map_err(|_| {
@@ -412,15 +510,13 @@ pub fn tree_context(
                 garden: garden_name.into(),
             }
         })?;
-        let mut contexts = garden_trees(app_context, config, &pattern);
-        if contexts.is_empty() {
-            // The current config may be a graft. Allow finding grafts from parents.
-            if let Some(parent_id) = config.parent_id {
-                let parent_config = app_context.get_config(parent_id);
-                contexts = garden_trees(app_context, parent_config, &pattern);
-                ctx.config = parent_config.get_id();
-            }
-        }
+        let contexts = garden_trees(
+            app_context,
+            app_context.get_root_config(),
+            Some(config),
+            &pattern,
+        );
+
         if contexts.is_empty() {
             return Err(errors::GardenError::GardenNotFound {
                 garden: garden_name.to_string(),
@@ -495,6 +591,7 @@ pub(crate) fn shared_worktree_path(
         let worktree = eval::tree_value(
             app_context,
             config,
+            None,
             tree.worktree.get_expr(),
             &ctx.tree,
             ctx.garden.as_ref(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -261,10 +261,9 @@ pub fn tree_from_name(
     if let Some(tree) = config.trees.get(tree_name) {
         return Some(model::TreeContext::new(
             tree.get_name(),
-            config.get_id(),
+            config.graft_id(),
             garden_name.cloned(),
             group.cloned(),
-            None,
         ));
     }
 
@@ -319,10 +318,9 @@ pub fn trees_from_pattern(
                 // Tree found in a grafted configuration.
                 result.push(model::TreeContext::new(
                     cfg_tree.get_name(),
-                    config.get_id(),
+                    graft_cfg.get_id(),
                     garden_name.cloned(),
                     group.cloned(),
-                    graft_cfg.get_id(),
                 ));
             }
         }
@@ -335,7 +333,6 @@ pub fn trees_from_pattern(
                 config.get_id(),
                 garden_name.cloned(),
                 group.cloned(),
-                None,
             ));
         }
     }
@@ -380,13 +377,7 @@ fn tree_from_pathbuf(
             Err(_) => continue,
         };
         if pathbuf == tree_canon {
-            return Some(model::TreeContext::new(
-                name,
-                config.get_id(),
-                None,
-                None,
-                None,
-            ));
+            return Some(model::TreeContext::new(name, config.get_id(), None, None));
         }
     }
 
@@ -410,13 +401,7 @@ fn tree_from_pathbuf(
                     Err(_) => continue,
                 };
                 if dirname == &tree_canon {
-                    return Some(model::TreeContext::new(
-                        name,
-                        config.get_id(),
-                        None,
-                        None,
-                        None,
-                    ));
+                    return Some(model::TreeContext::new(name, config.get_id(), None, None));
                 }
             }
         }
@@ -471,8 +456,7 @@ fn trees(config: &model::Configuration, pattern: &glob::Pattern) -> Vec<model::T
         if pattern.matches(tree_name) {
             result.push(model::TreeContext::new(
                 tree.get_name(),
-                config.get_id(),
-                None,
+                config.graft_id(),
                 None,
                 None,
             ));
@@ -500,8 +484,7 @@ pub fn tree_context(
     // and record the graft so that later lookups use the graft's context.
     // This is effectively the inverse of the recursive deepening performed by find_tree().
     if config.parent_id.is_some() {
-        ctx.config = app_context.get_root_config().get_id();
-        ctx.graft_config = config.get_id();
+        ctx.config = config.get_id();
     }
 
     if let Some(garden_name) = garden {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -46,6 +46,13 @@ pub(crate) fn is_graft(string: &str) -> bool {
     string.contains("::")
 }
 
+/// Return true if `string` is a candidate for evaluation.
+/// Returns true for strings with ${vars}  and "$ exec" expressions.
+#[inline]
+pub(crate) fn is_eval_candidate(string: &str) -> bool {
+    string.contains('$')
+}
+
 /// Return true if `string` ends in ".git". This is used to detect bare repositories.
 #[inline]
 pub(crate) fn is_git_dir(string: &str) -> bool {

--- a/tests/data/garden.yaml
+++ b/tests/data/garden.yaml
@@ -138,7 +138,9 @@ trees:
     variables:
       variable: "prebuilt ${graft::variable}"
       tree_variable: ${TREE_NAME}/env/value
+      tree_path: ${TREE_PATH}
     environment:
+      GARDEN_ENV_PATH: ${tree_path}
       GARDEN_ENV_VALUE: ${tree_variable}
 
 templates:
@@ -183,4 +185,5 @@ gardens:
       - trees/prebuilt
       - graft::grafted-env
     environment:
+      GARDEN_ENV_PATH: garden/path
       GARDEN_ENV_VALUE: garden/env

--- a/tests/data/garden.yaml
+++ b/tests/data/garden.yaml
@@ -137,6 +137,9 @@ trees:
     url: "file://${repos}/example.git"
     variables:
       variable: "prebuilt ${graft::variable}"
+      tree_variable: ${TREE_NAME}/env/value
+    environment:
+      GARDEN_ENV_VALUE: ${tree_variable}
 
 templates:
   echo-template-extended:
@@ -175,4 +178,9 @@ gardens:
     trees:
       - graft::prebuilt
       - trees/prebuilt
-
+  garden/env:
+    trees:
+      - trees/prebuilt
+      - graft::grafted-env
+    environment:
+      GARDEN_ENV_VALUE: garden/env

--- a/tests/data/grafts/graft.yaml
+++ b/tests/data/grafts/graft.yaml
@@ -28,4 +28,5 @@ trees:
     path: trees/prebuilt
   grafted-env:
     environment:
+      GARDEN_ENV_PATH: ${TREE_PATH}
       GARDEN_ENV_VALUE: graft/${TREE_NAME}/env/value

--- a/tests/data/grafts/graft.yaml
+++ b/tests/data/grafts/graft.yaml
@@ -26,3 +26,6 @@ trees:
     path: trees/prebuilt
   prebuilt2:
     path: trees/prebuilt
+  grafted-env:
+    environment:
+      GARDEN_ENV_VALUE: graft/${TREE_NAME}/env/value

--- a/tests/eval_test.rs
+++ b/tests/eval_test.rs
@@ -161,7 +161,7 @@ fn multi_variable_with_tree() -> Result<()> {
     let mut var = config.trees[1].environment[1].clone();
     assert_eq!("PATH", var.get_name());
 
-    let context = garden::model::TreeContext::new("cola", None, None, None, None);
+    let context = garden::model::TreeContext::new("cola", None, None, None);
     let values = garden::eval::multi_variable(&app_context, config, None, &mut var, &context);
     assert_eq!(
         values,
@@ -184,7 +184,7 @@ fn multi_variable_with_garden() -> Result<()> {
     let mut var = config.trees[1].environment[1].clone();
     assert_eq!("PATH", var.get_name());
 
-    let context = garden::model::TreeContext::new("cola", None, Some(string!("cola")), None, None);
+    let context = garden::model::TreeContext::new("cola", None, Some(string!("cola")), None);
     let values = garden::eval::multi_variable(&app_context, config, None, &mut var, &context);
     assert_eq!(
         values,
@@ -202,7 +202,7 @@ fn garden_environment() -> Result<()> {
     let app_context = common::garden_context()?;
     let config = app_context.get_root_config();
     // cola tree(1) and cola garden(Some(0))
-    let context = garden::model::TreeContext::new("cola", None, Some(string!("cola")), None, None);
+    let context = garden::model::TreeContext::new("cola", None, Some(string!("cola")), None);
     let values = garden::eval::environment(&app_context, config, &context);
     assert_eq!(values.len(), 9);
 
@@ -278,7 +278,7 @@ fn group_environment() -> Result<()> {
     let app_context = common::garden_context()?;
     let config = app_context.get_root_config();
     // cola tree(1) + cola group(Some(0))
-    let context = garden::model::TreeContext::new("cola", None, None, Some(string!("cola")), None);
+    let context = garden::model::TreeContext::new("cola", None, None, Some(string!("cola")));
     let values = garden::eval::environment(&app_context, config, &context);
     assert_eq!(values.len(), 7);
 
@@ -375,7 +375,7 @@ fn environment_empty_value() -> Result<()> {
 #[test]
 fn command_garden_scope() -> Result<()> {
     let app_context = common::garden_context()?;
-    let context = garden::model::TreeContext::new("cola", None, Some(string!("cola")), None, None);
+    let context = garden::model::TreeContext::new("cola", None, Some(string!("cola")), None);
 
     // Garden scope
     let values = garden::eval::command(&app_context, &context, "build");
@@ -393,7 +393,7 @@ fn command_garden_scope() -> Result<()> {
 #[test]
 fn command_tree_scope() -> Result<()> {
     let app_context = common::garden_context()?;
-    let context = garden::model::TreeContext::new("cola", None, None, None, None);
+    let context = garden::model::TreeContext::new("cola", None, None, None);
 
     // The ${prefix} variable should expand to the tree-local value.
     {
@@ -451,7 +451,7 @@ fn find_tree_in_graft() -> Result<()> {
     assert_eq!("graft", ctx.tree);
     assert!(ctx.config.is_some());
 
-    let node_id: usize = ctx.graft_config.unwrap().into();
+    let node_id: usize = ctx.config.unwrap().into();
     assert_eq!(2usize, node_id);
 
     Ok(())
@@ -467,11 +467,11 @@ fn eval_graft_tree() -> Result<()> {
     let ctx = garden::query::find_tree(&app_context, id, "graft::graft", None)?;
     assert!(ctx.config.is_some());
 
-    let node_id: usize = ctx.graft_config.unwrap().into();
+    let node_id: usize = ctx.config.unwrap().into();
     assert_eq!(2usize, node_id);
 
     // Evaluate the value for ${current_config} using the inner grafted config.
-    let graft_config = Some(app_context.get_config(ctx.graft_config.unwrap()));
+    let graft_config = Some(app_context.get_config(ctx.config.unwrap()));
     let path = garden::eval::tree_value(
         &app_context,
         app_context.get_root_config(),
@@ -495,10 +495,10 @@ fn eval_graft_tree() -> Result<()> {
 
     // Get a TreeContext for "example/tree".
     let example_ctx = garden::query::find_tree(&app_context, id, "example/tree", None)?;
-    assert!(example_ctx.config.is_some());
+    assert!(example_ctx.config.is_none());
 
     // Get the configuration for "example/tree".
-    let example_config = app_context.get_config(example_ctx.config.unwrap());
+    let example_config = app_context.get_config(id);
     // Evaluate "${current_config}" from the context of "example/tree".
     let actual = garden::eval::tree_value(
         &app_context,

--- a/tests/includes_test.rs
+++ b/tests/includes_test.rs
@@ -56,6 +56,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${template-variable}",
         &context.tree,
         None,
@@ -64,6 +65,7 @@ fn template_includes() -> Result<()> {
     let constant = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${template-constant}",
         &context.tree,
         None,
@@ -86,6 +88,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${template-variable}",
         &context.tree,
         None,
@@ -93,6 +96,7 @@ fn template_includes() -> Result<()> {
     let constant = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${template-constant}",
         &context.tree,
         None,
@@ -117,6 +121,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${template-variable}",
         &context.tree,
         None,
@@ -124,6 +129,7 @@ fn template_includes() -> Result<()> {
     let constant = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${template-constant}",
         &context.tree,
         None,
@@ -148,6 +154,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${template-variable}",
         &context.tree,
         None,
@@ -157,6 +164,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${tree-variable}",
         &context.tree,
         None,
@@ -166,6 +174,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${tree-override}",
         &context.tree,
         None,
@@ -179,6 +188,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${template-variable}",
         &context.tree,
         None,
@@ -188,6 +198,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${tree-override}",
         &context.tree,
         None,
@@ -198,6 +209,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${tree-variable}",
         &context.tree,
         None,
@@ -210,6 +222,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${extended-variable}",
         &context.tree,
         None,
@@ -222,6 +235,7 @@ fn template_includes() -> Result<()> {
     let result = garden::eval::tree_value(
         &app_context,
         config,
+        None,
         "${tree-variable}",
         &context.tree,
         None,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -659,6 +659,53 @@ fn eval_default_config_dir() {
     assert!(output.ends_with("/tests/data/config"));
 }
 
+/// `garden eval` evaluates variables from "environment" blocks.
+#[test]
+fn eval_environment_blocks() {
+    // garden --chdir tests/data eval '${GARDEN_ENV_VALUE}' trees/prebuilt
+    let expect = "trees/prebuilt/env/value";
+    let actual = garden_capture(&[
+        "--chdir",
+        "tests/data",
+        "eval",
+        "${GARDEN_ENV_VALUE}",
+        "trees/prebuilt",
+    ]);
+    assert_eq!(expect, actual);
+    // garden --chdir tests/data eval --env '${GARDEN_ENV_VALUE}' graft::prebuilt
+    let expect = "graft/grafted-env/env/value";
+    let actual = garden_capture(&[
+        "--chdir",
+        "tests/data",
+        "eval",
+        "${GARDEN_ENV_VALUE}",
+        "graft::grafted-env",
+    ]);
+    assert_eq!(expect, actual);
+    // garden --chdir tests/data eval --env '${GARDEN_ENV_VALUE}' trees/prebuilt garden/env
+    let expect = "garden/env:graft/grafted-env/env/value:trees/prebuilt/env/value";
+    let actual = garden_capture(&[
+        "--config",
+        "tests/data/garden.yaml",
+        "eval",
+        "${GARDEN_ENV_VALUE}",
+        "trees/prebuilt",
+        "garden/env",
+    ]);
+    assert_eq!(expect, actual);
+    // garden --chdir tests/data eval --env '${GARDEN_ENV_VALUE}' graft::prebuilt garden/env
+    let expect = "garden/env:graft/grafted-env/env/value:trees/prebuilt/env/value";
+    let actual = garden_capture(&[
+        "--config",
+        "tests/data/garden.yaml",
+        "eval",
+        "${GARDEN_ENV_VALUE}",
+        "graft::grafted-env",
+        "garden/env",
+    ]);
+    assert_eq!(expect, actual);
+}
+
 /// `garden::git::worktree_details(path)` returns a struct with branches and a
 /// GitTreeType (Tree, Bare, Parent, Worktree) for this worktree.
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -693,7 +693,7 @@ fn eval_environment_tree_names() {
         "garden/env",
     ]);
     assert_eq!(expect, actual);
-    // garden --chdir tests/data eval --env '${GARDEN_ENV_VALUE}' graft::prebuilt garden/env
+    // garden --config tests/data/garden.yaml tests/data eval '${GARDEN_ENV_VALUE}' graft::grafted-env garden/env
     let expect = "garden/env:graft/grafted-env/env/value:trees/prebuilt/env/value";
     let actual = garden_capture(&[
         "--config",
@@ -722,10 +722,24 @@ fn eval_environment_tree_paths() {
         actual.ends_with(expect),
         "{actual} does not end with {expect}"
     );
+    assert_eq!(1, actual.split(':').count());
+
+    // garden --chdir tests/data eval '${GARDEN_ENV_PATH}' graft::grafted-env
+    let expect = "/tests/data/grafted-env";
+    let actual = garden_capture(&[
+        "--chdir",
+        "tests/data",
+        "eval",
+        "${GARDEN_ENV_PATH}",
+        "graft::grafted-env",
+    ]);
+    assert!(
+        actual.ends_with(expect),
+        "{actual} does not end with {expect}"
+    );
+    assert_eq!(1, actual.split(':').count());
 
     // garden --chdir tests/data eval '${GARDEN_ENV_PATH}' trees/prebuilt garden/env
-    let expect = "/tests/data/trees/prebuilt";
-    let expect_start = "garden/path:";
     let actual = garden_capture(&[
         "--chdir",
         "tests/data",
@@ -734,13 +748,45 @@ fn eval_environment_tree_paths() {
         "trees/prebuilt",
         "garden/env",
     ]);
+    let actual_items: Vec<&str> = actual.split(':').collect();
+    assert_eq!(actual_items.len(), 3);
+    assert_eq!(actual_items[0], "garden/path");
+    let expect = "/tests/data/grafted-env";
     assert!(
-        actual.ends_with(expect),
-        "{actual} does not end with {expect}"
+        actual_items[1].ends_with(expect),
+        "{} does not end with {expect}",
+        actual_items[1]
     );
+    let expect = "/tests/data/trees/prebuilt";
     assert!(
-        actual.starts_with(expect_start),
-        "{actual} does not start with {expect_start}"
+        actual_items[2].ends_with(expect),
+        "{} does not end with {expect}",
+        actual_items[2]
+    );
+
+    // garden --chdir tests/data eval '${GARDEN_ENV_PATH}' trees/prebuilt garden/env
+    let actual = garden_capture(&[
+        "--chdir",
+        "tests/data",
+        "eval",
+        "${GARDEN_ENV_PATH}",
+        "graft::grafted-env",
+        "garden/env",
+    ]);
+    let actual_items: Vec<&str> = actual.split(':').collect();
+    assert_eq!(actual_items.len(), 3);
+    assert_eq!(actual_items[0], "garden/path");
+    let expect = "/tests/data/grafted-env";
+    assert!(
+        actual_items[1].ends_with(expect),
+        "{} does not end with {expect}",
+        actual_items[1]
+    );
+    let expect = "/tests/data/trees/prebuilt";
+    assert!(
+        actual_items[2].ends_with(expect),
+        "{} does not end with {expect}",
+        actual_items[2]
     );
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -661,7 +661,7 @@ fn eval_default_config_dir() {
 
 /// `garden eval` evaluates variables from "environment" blocks.
 #[test]
-fn eval_environment_blocks() {
+fn eval_environment_tree_names() {
     // garden --chdir tests/data eval '${GARDEN_ENV_VALUE}' trees/prebuilt
     let expect = "trees/prebuilt/env/value";
     let actual = garden_capture(&[
@@ -704,6 +704,44 @@ fn eval_environment_blocks() {
         "garden/env",
     ]);
     assert_eq!(expect, actual);
+}
+
+/// `garden eval` evaluates TREE_PATH variables in "environment" blocks.
+#[test]
+fn eval_environment_tree_paths() {
+    // garden --chdir tests/data eval '${GARDEN_ENV_PATH}' trees/prebuilt
+    let expect = "/tests/data/trees/prebuilt";
+    let actual = garden_capture(&[
+        "--chdir",
+        "tests/data",
+        "eval",
+        "${GARDEN_ENV_PATH}",
+        "trees/prebuilt",
+    ]);
+    assert!(
+        actual.ends_with(expect),
+        "{actual} does not end with {expect}"
+    );
+
+    // garden --chdir tests/data eval '${GARDEN_ENV_PATH}' trees/prebuilt garden/env
+    let expect = "/tests/data/trees/prebuilt";
+    let expect_start = "garden/path:";
+    let actual = garden_capture(&[
+        "--chdir",
+        "tests/data",
+        "eval",
+        "${GARDEN_ENV_PATH}",
+        "trees/prebuilt",
+        "garden/env",
+    ]);
+    assert!(
+        actual.ends_with(expect),
+        "{actual} does not end with {expect}"
+    );
+    assert!(
+        actual.starts_with(expect_start),
+        "{actual} does not start with {expect_start}"
+    );
 }
 
 /// `garden::git::worktree_details(path)` returns a struct with branches and a

--- a/tests/query_test.rs
+++ b/tests/query_test.rs
@@ -12,7 +12,7 @@ use garden::string;
 fn resolve_trees_default_query_finds_garden() -> Result<()> {
     let app_context = common::garden_context()?;
     let config = app_context.get_root_config();
-    let result = garden::query::resolve_trees(&app_context, config, "cola");
+    let result = garden::query::resolve_trees(&app_context, config, None, "cola");
     assert_eq!(3, result.len());
     assert_eq!(Some(string!("cola")), result[0].garden);
     assert_eq!("git", result[0].tree);
@@ -28,7 +28,7 @@ fn resolve_trees_default_query_finds_garden() -> Result<()> {
 fn resolve_trees_tree_query_wildcard() -> Result<()> {
     let app_context = common::garden_context()?;
     let config = app_context.get_root_config();
-    let result = garden::query::resolve_trees(&app_context, config, "@c*");
+    let result = garden::query::resolve_trees(&app_context, config, None, "@c*");
     assert_eq!(1, result.len());
     assert_eq!(None, result[0].garden);
     assert_eq!(None, result[0].group);
@@ -41,7 +41,7 @@ fn resolve_trees_tree_query_wildcard() -> Result<()> {
 fn resolve_trees_group_query() -> Result<()> {
     let app_context = common::garden_context()?;
     let config = app_context.get_root_config();
-    let result = garden::query::resolve_trees(&app_context, config, "%rev*");
+    let result = garden::query::resolve_trees(&app_context, config, None, "%rev*");
     assert_eq!(2, result.len());
     assert_eq!(None, result[0].garden);
     assert_eq!(Some(string!("reverse")), result[0].group);
@@ -58,7 +58,7 @@ fn resolve_trees_group_with_wildcards() -> Result<()> {
     let app_context = common::garden_context()?;
     let config = app_context.get_root_config();
     // annex group
-    let result = garden::query::resolve_trees(&app_context, config, "%annex");
+    let result = garden::query::resolve_trees(&app_context, config, None, "%annex");
     assert_eq!(2, result.len());
     // annex/data
     assert_eq!(None, result[0].garden);
@@ -76,7 +76,8 @@ fn resolve_trees_group_with_wildcards() -> Result<()> {
 fn trees_from_pattern() -> Result<()> {
     let app_context = common::garden_context()?;
     let config = app_context.get_root_config();
-    let result = garden::query::trees_from_pattern(&app_context, config, "annex/*", None, None);
+    let result =
+        garden::query::trees_from_pattern(&app_context, config, None, "annex/*", None, None);
     assert_eq!(2, result.len());
     assert_eq!(None, result[0].garden);
     assert_eq!(None, result[0].group);
@@ -97,7 +98,7 @@ fn trees_from_group() -> Result<()> {
     let annex_grp = config.groups.get("annex").context("Missing annex group")?;
     assert_eq!("annex", annex_grp.get_name());
 
-    let result = garden::query::trees_from_group(&app_context, config, None, annex_grp);
+    let result = garden::query::trees_from_group(&app_context, config, None, None, annex_grp);
     assert_eq!(2, result.len());
     assert_eq!(None, result[0].garden);
     assert_eq!(Some(string!("annex")), result[0].group);
@@ -117,7 +118,7 @@ fn trees_from_garden() -> Result<()> {
 
     // regular group, group uses wildcards
     let annex_group = config.gardens.get("annex/group").context("annex/group")?;
-    let mut result = garden::query::trees_from_garden(&app_context, config, annex_group);
+    let mut result = garden::query::trees_from_garden(&app_context, config, None, annex_group);
     assert_eq!(2, result.len());
 
     // annex/group
@@ -134,7 +135,7 @@ fn trees_from_garden() -> Result<()> {
         .gardens
         .get("annex/wildcard-groups")
         .context("annex/wildcard-groups")?;
-    result = garden::query::trees_from_garden(&app_context, config, annex_wild_groups);
+    result = garden::query::trees_from_garden(&app_context, config, None, annex_wild_groups);
     assert_eq!(2, result.len());
 
     // annex/Wildcard-groups
@@ -151,7 +152,7 @@ fn trees_from_garden() -> Result<()> {
         .gardens
         .get("annex/wildcard-trees")
         .context("annex/wildcard-trees")?;
-    result = garden::query::trees_from_garden(&app_context, config, annex_wild_trees);
+    result = garden::query::trees_from_garden(&app_context, config, None, annex_wild_trees);
     assert_eq!(2, result.len());
 
     assert_eq!(Some(string!("annex/wildcard-trees")), result[0].garden);


### PR DESCRIPTION
Garden `${variables}` do not currently take environment blocks into account.

Teach the evaluation machinery to evaluate environment blocks.