### PR TITLE
cmds: make "zsh" split words just like other shells

### DIFF
--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -21,6 +21,14 @@
   when a variable with a cyclical expression is evaluated.
   ([#24](https://github.com/davvid/garden/pull/24))
 
+- When `zsh` is used as the `garden.shell`, which happens automatically when `zsh`
+  is installed, `garden` will now use `zsh -o shwordsplit` in order to enable
+  word-splitting of `$variable` expressions by default. This makes `zsh` behave
+  just like other shells by default, which improves the portability of commands.
+  Configure `garden.shell-wordsplit` to `false` or use the
+  `garden <cmd> -z | --no-wordsplit` option to opt-out of this behavior.
+  ([#25](https://github.com/davvid/garden/pull/25))
+
 
 ## v1.2.1
 

--- a/doc/src/commands.md
+++ b/doc/src/commands.md
@@ -357,8 +357,16 @@ The `--no-errexit` option causes commands with multiple statements to run to com
 even when a non-zero exit code is encountered. This is akin to a regular shell script.
 
 Configure `garden.shell-errexit` to `false` in `garden.yaml` to opt-out of this behavior.
-You can also opt-out of the `errexit` behavior on a per-command basis by adding
+You can also opt-out of the `errexit` behavior on a per-command basis by using
 `set +e` as the first line of a multi-line command.
+
+When `zsh` is used it is executed with the `-o shwordsplit` option so that zsh behaves
+similarly to traditional shells and splits words in unquoted `$variable` expressions
+rather than treating `$variable` like a single argument.
+
+Configure `garden.shell-wordsplit` to `false` to opt-out of this behavior.
+You can also opt-out of the `shwordsplit` behavior on a per-command basis by using
+`set +o shwordsplit` as the first line of a multi-line command.
 
 Additional command-line `<arguments>` specified after a double-dash (`--`)
 end-of-options marker are forwarded to each command.

--- a/src/cmds/completion.rs
+++ b/src/cmds/completion.rs
@@ -36,10 +36,16 @@ pub fn main(options: &cli::MainOptions, completion_options: &CompletionOptions) 
                             .long("keep-going"),
                     )
                     .arg(
-                        Arg::new("no_errexit")
+                        Arg::new("no-errexit")
                             .help("Do not pass -e to the shell")
                             .short('n')
                             .long("no-errexit"),
+                    )
+                    .arg(
+                        Arg::new("no-wordsplit")
+                            .help("Do not pass -o shwordsplit to zsh")
+                            .short('z')
+                            .long("no-wordsplit"),
                     )
                     .arg(
                         Arg::new("queries")

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -71,8 +71,21 @@ fn parse_recursive(
     ) && config_verbose > 0
     {
         debug!(
-            "yaml: garden.shell-errexit = {}",
+            "config: {} = {}",
+            constants::GARDEN_SHELL_ERREXIT,
             config.shell_exit_on_error
+        );
+    }
+    // garden.shell-wordsplit
+    if get_bool(
+        &doc[constants::GARDEN][constants::SHELL_WORDSPLIT],
+        &mut config.shell_word_split,
+    ) && config_verbose > 0
+    {
+        debug!(
+            "config: {} = {}",
+            constants::GARDEN_SHELL_WORDSPLIT,
+            config.shell_word_split
         );
     }
     // garden.tree-branches
@@ -81,7 +94,11 @@ fn parse_recursive(
         &mut config.tree_branches,
     ) && config_verbose > 0
     {
-        debug!("yaml: garden.tree-branches = {}", config.tree_branches);
+        debug!(
+            "config: {} = {}",
+            constants::GARDEN_TREE_BRANCHES,
+            config.tree_branches
+        );
     }
 
     // GARDEN_ROOT and GARDEN_CONFIG_DIR are relative to the root configuration.

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -56,13 +56,13 @@ fn parse_recursive(
             config.root_is_dynamic = true;
         }
         if config_verbose > 0 {
-            debug!("yaml: garden.root = {}", config.root.get_expr());
+            debug!("config: garden.root = {}", config.root.get_expr());
         }
     }
 
     // garden.shell
     if get_str(&doc[constants::GARDEN][constants::SHELL], &mut config.shell) && config_verbose > 0 {
-        debug!("yaml: garden.shell = {}", config.shell);
+        debug!("config: {} = {}", constants::GARDEN_SHELL, config.shell);
     }
     // garden.shell-errexit
     if get_bool(
@@ -88,7 +88,7 @@ fn parse_recursive(
     // Referencing these variables from garden files included using garden.includes
     // resolves to the root config's location, not the included location.
     if config_verbose > 1 {
-        debug!("yaml: built-in variables");
+        debug!("config: built-in variables");
     }
     // Provide GARDEN_ROOT.
     config.variables.insert(
@@ -111,7 +111,7 @@ fn parse_recursive(
     if !get_variables_hashmap(&doc[constants::VARIABLES], &mut config.variables)
         && config_verbose > 1
     {
-        debug!("yaml: no variables");
+        debug!("config: no variables");
     }
 
     // Process "includes" after initializing the GARDEN_ROOT and GARDEN_CONFIG_DIR.
@@ -160,33 +160,33 @@ fn parse_recursive(
         if !get_variables_hashmap(&doc[constants::VARIABLES], &mut config.variables)
             && config_verbose > 1
         {
-            debug!("yaml: no reloaded variables");
+            debug!("config: no reloaded variables");
         }
     }
 
     // grafts
     if config_verbose > 1 {
-        debug!("yaml: grafts");
+        debug!("config: grafts");
     }
     if !get_grafts(&doc[constants::GRAFTS], &mut config.grafts) && config_verbose > 1 {
-        debug!("yaml: no grafts");
+        debug!("config: no grafts");
     }
 
     get_multivariables(&doc[constants::ENVIRONMENT], &mut config.environment);
 
     // commands
     if config_verbose > 1 {
-        debug!("yaml: commands");
+        debug!("config: commands");
     }
     if !get_multivariables_hashmap(&doc[constants::COMMANDS], &mut config.commands)
         && config_verbose > 1
     {
-        debug!("yaml: no commands");
+        debug!("config: no commands");
     }
 
     // templates
     if config_verbose > 1 {
-        debug!("yaml: templates");
+        debug!("config: templates");
     }
     if !get_templates(
         &doc["templates"],
@@ -194,31 +194,31 @@ fn parse_recursive(
         &mut config.templates,
     ) && config_verbose > 1
     {
-        debug!("yaml: no templates");
+        debug!("config: no templates");
     }
 
     // trees
     if config_verbose > 1 {
-        debug!("yaml: trees");
+        debug!("config: trees");
     }
     if !get_trees(app_context, config, &doc[constants::TREES]) && config_verbose > 1 {
-        debug!("yaml: no trees");
+        debug!("config: no trees");
     }
 
     // groups
     if config_verbose > 1 {
-        debug!("yaml: groups");
+        debug!("config: groups");
     }
     if !get_groups(&doc[constants::GROUPS], &mut config.groups) && config_verbose > 1 {
-        debug!("yaml: no groups");
+        debug!("config: no groups");
     }
 
     // gardens
     if config_verbose > 1 {
-        debug!("yaml: gardens");
+        debug!("config: gardens");
     }
     if !get_gardens(&doc[constants::GARDENS], &mut config.gardens) && config_verbose > 1 {
-        debug!("yaml: no gardens");
+        debug!("config: no gardens");
     }
 
     Ok(())

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -74,6 +74,12 @@ pub const GARDEN_CONFIG_DIR_EXPR: &str = "${GARDEN_CONFIG_DIR}";
 /// Builtin variable for the "garden.root" location where trees are grown.
 pub const GARDEN_ROOT: &str = "GARDEN_ROOT";
 
+/// Command-line defines for overriding configurable behavior.
+pub(crate) const GARDEN_SHELL: &str = "garden.shell";
+pub(crate) const GARDEN_SHELL_ERREXIT: &str = "garden.shell-errexit";
+pub(crate) const GARDEN_SHELL_WORDSPLIT: &str = "garden.shell-wordsplit";
+pub(crate) const GARDEN_TREE_BRANCHES: &str = "garden.tree-branches";
+
 /// The "gitconfig" section in a tree block defines local ".git/config"
 /// settings that are applied when a tree is grown.
 pub const GITCONFIG: &str = "gitconfig";
@@ -128,6 +134,9 @@ pub(crate) const SHELL_DASH: &str = "dash";
 /// The "shell-errexit" key in the garden block disables the "exit on error"
 /// shell option.
 pub const SHELL_ERREXIT: &str = "shell-errexit";
+
+/// The "shell-wordsplit" key in the garden block disables the `zsh -o shwordsplit` option.
+pub const SHELL_WORDSPLIT: &str = "shell-wordsplit";
 
 /// KornShell is a standard/restricted command and programming language.
 pub(crate) const SHELL_KSH: &str = "ksh";

--- a/tests/data/garden.yaml
+++ b/tests/data/garden.yaml
@@ -83,7 +83,12 @@ trees:
       echo-pre-and-post-nested>: echo-pre-and-post-nested-after
       echo-pre-and-post-nested-after>: echo-pre-and-post-nested-fini
       echo-pre-and-post-nested-fini: echo fini
-
+      echo-wordsplit-variable: |
+        abc='a b c'
+        for arg in $abc
+        do
+            echo $arg
+        done
   example/shallow:
     path: example/tree/shallow
     url: file://${repos}/example.git

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -4,11 +4,11 @@ use common::{
     BareRepoFixture,
 };
 
-use garden::git;
-use garden::model;
+use garden::{git, model};
 
 use anyhow::Result;
 use function_name::named;
+use which::which;
 
 /// `garden init` adds the current repository
 #[test]
@@ -1877,6 +1877,49 @@ fn cmd_shell_variables() {
     assert_eq!(output, "test array value");
 }
 
+/// Test the behavior of garden.shell-wordsplit.
+/// $shell variables subject to word splitting byh default unless
+/// garden.shell-wordsplit is set false.
+#[test]
+fn cmd_zsh_shell_wordsplit() {
+    if which("zsh").is_err() {
+        return;
+    }
+    // Words are split by default.
+    let output = garden_capture(&[
+        "--config",
+        "tests/data/garden.yaml",
+        "--define",
+        "garden.shell=zsh",
+        "--quiet",
+        "echo-wordsplit-variable",
+    ]);
+    assert_eq!(output, "a\nb\nc");
+    // Use garden.shell-wordsplit=false to disable word splitting.
+    let output = garden_capture(&[
+        "--config",
+        "tests/data/garden.yaml",
+        "--define",
+        "garden.shell=zsh",
+        "--define",
+        "garden.shell-wordsplit=false",
+        "--quiet",
+        "echo-wordsplit-variable",
+    ]);
+    assert_eq!(output, "a b c");
+    // use --no-wordsplit to disable word splitting.
+    let output = garden_capture(&[
+        "--config",
+        "tests/data/garden.yaml",
+        "--define",
+        "garden.shell=zsh",
+        "--quiet",
+        "echo-wordsplit-variable",
+        "--no-wordsplit",
+    ]);
+    // Words are split by default.
+    assert_eq!(output, "a b c");
+}
 /// "garden prune" prunes specific depths
 #[test]
 #[named]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1348,7 +1348,6 @@ fn cmd_no_errexit() {
         "error-command",
     ]);
     assert_eq!(output, "ok");
-
     let output = garden_capture(&[
         "--chdir",
         "tests/data",
@@ -1356,6 +1355,15 @@ fn cmd_no_errexit() {
         "cmd",
         "--no-errexit",
         ".",
+        "error-command",
+    ]);
+    assert_eq!(output, "ok\nafter error");
+    let output = garden_capture(&[
+        "--chdir",
+        "tests/data",
+        "--define",
+        "garden.shell-errexit=false",
+        "--quiet",
         "error-command",
     ]);
     assert_eq!(output, "ok\nafter error");


### PR DESCRIPTION
Use the "zsh -o shwordsplit" option by default to improve portability
of garden commands. zsh does not split words by default, which makes
the behavior of $variable expressions different from bash.
    
Add a garden.shell-wordsplit option to opt-out of this behavior
and use the default zsh behavior where unquoted $variable expressions
are not subject to word splitting.