### PR TITLE
garden: add support for custom shell commands

### DIFF
--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -50,6 +50,10 @@
   configuring the `garden.interactive-shell` value.
   ([#26](https://github.com/davvid/garden/pull/26))
 
+- `garden shell` can now be run without any arguments. The tree query now defaults to
+  `.` so that the tree in the current directory is used when nothing is specified.
+  ([#26](https://github.com/davvid/garden/pull/26))
+
 
 ## v1.2.1
 

--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -29,6 +29,27 @@
   `garden <cmd> -z | --no-wordsplit` option to opt-out of this behavior.
   ([#25](https://github.com/davvid/garden/pull/25))
 
+- `garden.shell` can now be configured to use arbitrary commands for executing
+  command strings. Garden uses the configured `garden.shell` as-is and does
+  not augment its options (e.g. `-e`  or `-o shwordsplit`) when a custom command
+  is used. Custom commands are identified as commands that expand to 2 or more
+  command-line arguments. Thus, `python3` is not considered a custom command
+  and `garden` will run `python3 -c <string>` to run commands. On the other
+  hand, specifying `ruby -e` *is* considered a custom command because it
+  expands to `["ruby", "-e"]` under the hood. If you need to use a custom
+  command  that takes no additional command-line arguments then you can
+  use `env` as an extra argument to have it be considered as a custom shell.
+  For example, `env custom-shell` will cause `garden` to run
+  `env custom-shell <string>`, which is equivalent to `custom-shell <string>`.
+  Using just `custom-shell` would have resulted in `garden` running
+  `custom-shell -c <string>` instead, which may not be desired.
+  ([#26](https://github.com/davvid/garden/pull/26))
+
+- The `garden shell` command can now be configured to use an interactive command shell
+  that is distinct from the command specified in the `garden.shell` configuration by
+  configuring the `garden.interactive-shell` value.
+  ([#26](https://github.com/davvid/garden/pull/26))
+
 
 ## v1.2.1
 

--- a/doc/src/commands.md
+++ b/doc/src/commands.md
@@ -341,33 +341,6 @@ by the garden's `test` command.
 Commands are executed in a shell so that shell expressions can be used in commands.
 A POSIX-compatible shell must be installed in your `$PATH`.
 
-The `garden.shell` configuration value defaults to `zsh` but can be set to any
-shell that accepts `-e` and `-c '<command>` options (for example `bash`).
-If `zsh` is not installed then `bash` will be used by default instead.
-If neither `zsh` nor `bash` is installed then `sh` will be used by default instead.
-
-Each command runs under `["zsh", "-e", "-c", "<command>"]` with the resolved
-environment from the corresponding garden, group, or tree.
-
-Multi-line and multi-statement command strings will stop executing as soon as the
-first non-zero exit code is encountered due to the use of the `-e` shell option.
-Use the `-n | --no-errexit` option to inhibit the use of the `-e` "errexit" option.
-
-The `--no-errexit` option causes commands with multiple statements to run to completion
-even when a non-zero exit code is encountered. This is akin to a regular shell script.
-
-Configure `garden.shell-errexit` to `false` in `garden.yaml` to opt-out of this behavior.
-You can also opt-out of the `errexit` behavior on a per-command basis by using
-`set +e` as the first line of a multi-line command.
-
-When `zsh` is used it is executed with the `-o shwordsplit` option so that zsh behaves
-similarly to traditional shells and splits words in unquoted `$variable` expressions
-rather than treating `$variable` like a single argument.
-
-Configure `garden.shell-wordsplit` to `false` to opt-out of this behavior.
-You can also opt-out of the `shwordsplit` behavior on a per-command basis by using
-`set +o shwordsplit` as the first line of a multi-line command.
-
 Additional command-line `<arguments>` specified after a double-dash (`--`)
 end-of-options marker are forwarded to each command.
 
@@ -395,23 +368,100 @@ commands:
     - |
       echo b $3
       echo c $4
-
 variables:
   name: value
   debian: $ type apt-get >/dev/null && echo yes || echo no
-
 # Commands can also be defined at tree and garden scope
-
 trees:
   our-tree:
     commands:
       tree-cmd: echo ${TREE_NAME}
-
 gardens:
   all:
     trees: "*"
     commands:
       print-pwd: pwd
+```
+
+### Garden Shell
+
+The `garden.shell` configuration value controls which shell interpreter
+is used to interpret custom commands.
+
+```yaml
+garden:
+  shell: zsh  # zsh is used by default when available. Uses bash, dash or sh otherwise.
+  shell-wordsplit: true  # Words are split by default in zsh using "zsh -o shwordsplit"
+  shell-errexit: true  # Non-zero exit status stops execution using "zsh -e".
+```
+
+`garden.shell` defaults to `zsh` when `zsh` is installed but can be set to any shell
+that accepts `-e` and `-c '<string>` options (for example `ksh`).
+If `zsh` is not installed then `bash` or `dash` will be used instead.
+If neither `zsh`, `bash` nor `dash` is installed then `sh` will be used.
+
+Each command runs under `["zsh", "-e", "-c", "<command>"]` with the resolved
+environment from the corresponding garden, group, or tree.
+
+Multi-line and multi-statement command strings will stop executing as soon as the
+first non-zero exit code is encountered due to the use of the `-e` shell option.
+Use the `-n | --no-errexit` option to inhibit the use of the `-e` "errexit" option.
+
+The `--no-errexit` option causes commands with multiple statements to run to completion
+even when a non-zero exit code is encountered. This is akin to a regular shell script.
+
+Configure `garden.shell-errexit` to `false` in `garden.yaml` to opt-out of this behavior.
+You can also opt-out of the `errexit` behavior on a per-command basis by using
+`set +e` as the first line of a multi-line command.
+
+When `zsh` is used it is executed with the `-o shwordsplit` option so that zsh behaves
+similarly to traditional shells by splitting words in unquoted `$variable` expressions
+rather than treating `$variable` like a single argument.
+
+Configure `garden.shell-wordsplit` to `false` to opt-out of this behavior.
+You can also opt-out of the `shwordsplit` behavior on a per-command basis by using
+`set +o shwordsplit` as the first line of a multi-line command.
+
+#### Custom Command Interpreters
+
+The command used in `garden.shell` must specify a command that takes a string to
+execute using the `-c <string>` option. Some commands take `-e <string>` instead,
+namely `nodejs`, `perl` and `ruby`, which are all understood by `garden` and
+are expanded into their corresponding command-line.
+
+This allows you to specify `python3` as the shell because `garden` assumes that
+it can call `python3 -c <string>` to execute commands.
+
+```yaml
+garden:
+  shell: python3  # Uses "python -c <string>" to run commands.
+commands:
+  greet: print('hello')  # Interpreted by python3.
+
+# Builtin shorthand shell values are special-cased internally.
+garden:
+   shell: zsh  # Uses "zsh -o shwordsplit -e -c <string>" to run commands.
+
+garden:
+   shell: bash  # Uses "bash -e -c <string>" to run commands.
+```
+
+`garden.shell` also allows you to completely override the command used for interpreting
+custom commands. When you specify a command line with multiple arguments then `garden`
+will no longer internally manage the command-line options passed to the shell command.
+The options that you specify will be used instead. You must specify `-c` or similar
+arguments yourself when `garden` is configured with a custom command.
+The `garden.shell-wordsplit` and `garden.shell-errexit` options have no effect
+when using custom shell commands.
+
+```yaml
+# Use "zsh -c" directly without "-o shwordsplit" and "-e".
+garden:
+  shell: zsh -c
+
+# Additional examples.
+garden:
+  shell: python3 -s -u -c
 ```
 
 ### Shell Syntax

--- a/doc/src/commands.md
+++ b/doc/src/commands.md
@@ -422,6 +422,33 @@ Configure `garden.shell-wordsplit` to `false` to opt-out of this behavior.
 You can also opt-out of the `shwordsplit` behavior on a per-command basis by using
 `set +o shwordsplit` as the first line of a multi-line command.
 
+#### Builtin Shells
+
+The following values for `garden.shell` are understood directly by `garden` and
+the following commands are used when `garden` detects that these shells are
+configured.
+
+| garden.shell  | Command used for running commands | errexit=false | wordsplit=false       |
+|---------------|-----------------------------------|---------------|-----------------------|
+| `bun`         | `bun -e`                          | N/A           | N/A                   |
+| `bash`        | `bash -e -c`                      | Omit `-e`     | N/A                   |
+| `dash`        | `dash -e -c`                      | Omit `-e`     | N/A                   |
+| `ksh`         | `ksh -e -c`                       | Omit `-e`     | N/A                   |
+| `node`        | `node -e`                         | N/A           | N/A                   |
+| `nodejs`      | `nodejs -e`                       | N/A           | N/A                   |
+| `perl`        | `perl -e`                         | N/A           | N/A                   |
+| `ruby`        | `ruby -e`                         | N/A           | N/A                   |
+| `sh`          | `sh -e -c`                        | Omit `-e`     | N/A                   |
+| `zsh`         | `zsh -e -o shwordsplit -c`        | Omit `-e`     | Omit `-o shwordsplit` |
+
+The following shells are not builtin, but they work as expected because they accept
+`-c <string>` arguments for running command strings.
+
+| garden.shell  | Command used for running commands |
+|---------------|-----------------------------------|
+| `fish`        | `fish -c`                         |
+| `python3`     | `python3 -c`                      |
+
 #### Custom Command Interpreters
 
 The command used in `garden.shell` must specify a command that takes a string to
@@ -687,6 +714,7 @@ If no tree-queries are specified then `garden ls` behaves as if
 Use the `-t | --trees` option to specify a glob pattern that can be used to
 filter trees by name post-query. This is useful when you want to list details
 about a group or garden while only listing details about a subset of the trees.
+
 
 ## garden prune
 

--- a/doc/src/commands.md
+++ b/doc/src/commands.md
@@ -698,6 +698,24 @@ The optional tree argument is not needed for the case where a garden
 and tree share a name -- garden will chdir into that same-named tree when
 creating the shell.
 
+If you would like to customize the command to use for `garden shell` then
+you can configure `garden.interactive-shell`. This value overrides `garden.shell`
+and is only used by the `garden shell` command.
+
+```yaml
+# Launch a fish login shell for "garden shell".
+garden:
+  interactive-shell: fish
+```
+
+Arbitrary command interpreters can be specified.
+
+```yaml
+# Launch a python interpreter for "garden shell".
+garden:
+  interactive-shell: python3 -B
+```
+
 
 ## garden ls
 

--- a/src/cmds/shell.rs
+++ b/src/cmds/shell.rs
@@ -54,12 +54,16 @@ pub fn main(app_context: &model::ApplicationContext, options: &ShellOptions) -> 
 
     // Evaluate garden.shell
     let graft_config = context.config.map(|id| app_context.get_config(id));
-    let shell_expr = config.shell.clone();
+    let shell_expr = if config.interactive_shell.is_empty() {
+        &config.shell
+    } else {
+        &config.interactive_shell
+    };
     let shell = eval::tree_value(
         app_context,
         config,
         graft_config,
-        &shell_expr,
+        shell_expr,
         &context.tree,
         context.garden.as_ref(),
     );

--- a/src/cmds/shell.rs
+++ b/src/cmds/shell.rs
@@ -8,6 +8,7 @@ use crate::{cmd, errors, eval, model, query};
 #[command(author, about, long_about)]
 pub struct ShellOptions {
     /// Query for trees to build an environment
+    #[arg(default_value = ".")]
     query: String,
     /// Tree to chdir into
     tree: Option<String>,

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -64,6 +64,19 @@ fn parse_recursive(
     if get_str(&doc[constants::GARDEN][constants::SHELL], &mut config.shell) && config_verbose > 0 {
         debug!("config: {} = {}", constants::GARDEN_SHELL, config.shell);
     }
+    // garden.interactive-shell
+    if get_str(
+        &doc[constants::GARDEN][constants::INTERACTIVE_SHELL],
+        &mut config.interactive_shell,
+    ) && config_verbose > 0
+    {
+        debug!(
+            "config: {} = {}",
+            constants::GARDEN_INTERACTIVE_SHELL,
+            config.interactive_shell
+        );
+    }
+
     // garden.shell-errexit
     if get_bool(
         &doc[constants::GARDEN][constants::SHELL_ERREXIT],

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -153,6 +153,9 @@ pub(crate) const SHELL_PERL: &str = "perl";
 /// Default command interpreter.
 pub(crate) const SHELL_SH: &str = "sh";
 
+/// A dynamic, open source programming language with a focus on simplicity and productivity.
+pub(crate) const SHELL_RUBY: &str = "ruby";
+
 /// Extended version of the Bourne Shell with new features.
 pub(crate) const SHELL_ZSH: &str = "zsh";
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -75,6 +75,7 @@ pub const GARDEN_CONFIG_DIR_EXPR: &str = "${GARDEN_CONFIG_DIR}";
 pub const GARDEN_ROOT: &str = "GARDEN_ROOT";
 
 /// Command-line defines for overriding configurable behavior.
+pub(crate) const GARDEN_INTERACTIVE_SHELL: &str = "garden.interactive-shell";
 pub(crate) const GARDEN_SHELL: &str = "garden.shell";
 pub(crate) const GARDEN_SHELL_ERREXIT: &str = "garden.shell-errexit";
 pub(crate) const GARDEN_SHELL_WORDSPLIT: &str = "garden.shell-wordsplit";
@@ -94,6 +95,10 @@ pub const GROUPS: &str = "groups";
 /// The "includes" key in the garden block reads additional configuration
 /// files directly into the configuration.
 pub const INCLUDES: &str = "includes";
+
+/// The "interactive-shell" key in the garden block overrides the
+/// command used by interactive "garden shell" sessions.
+pub const INTERACTIVE_SHELL: &str = "interactive-shell";
 
 /// The "links" key in a tree block defines URLs displayed by "garden ls".
 pub const LINKS: &str = "links";

--- a/src/model.rs
+++ b/src/model.rs
@@ -494,6 +494,7 @@ pub struct Configuration {
     pub root_is_dynamic: bool,
     pub root_path: std::path::PathBuf,
     pub shell: String,
+    pub interactive_shell: String,
     pub templates: HashMap<String, Template>,
     pub tree_search_path: Vec<std::path::PathBuf>,
     pub trees: IndexMap<TreeName, Tree>,
@@ -670,6 +671,9 @@ impl Configuration {
             }
             // Allow overridding garden.<value> using "garden -D garden.<value>=false".
             match name.as_str() {
+                constants::GARDEN_INTERACTIVE_SHELL => {
+                    self.interactive_shell = expr;
+                }
                 constants::GARDEN_SHELL => {
                     self.shell = expr;
                 }

--- a/tests/data/shell/custom.yaml
+++ b/tests/data/shell/custom.yaml
@@ -1,5 +1,6 @@
 garden:
   shell: zsh -c
+  interactive-shell: zsh
 
 commands:
   shell-words: |

--- a/tests/data/shell/custom.yaml
+++ b/tests/data/shell/custom.yaml
@@ -1,0 +1,10 @@
+garden:
+  shell: zsh -c
+
+commands:
+  shell-words: |
+    args='a b c'
+    for arg in $args
+    do
+        echo $arg
+    done

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1579,6 +1579,30 @@ fn cmd_pre_and_post_nested_commands() {
     assert_eq!(output, "pre\ncmd\ndata\npost\nnested\nfini");
 }
 
+/// Test custom shells in "garden.shell".
+#[test]
+fn cmd_shell_with_custom_command() {
+    if !which("zsh").is_ok() {
+        return;
+    }
+    let output = garden_capture(&[
+        "--config",
+        "tests/data/shell/custom.yaml",
+        "--quiet",
+        "shell-words",
+    ]);
+    assert_eq!(output, "a b c");
+    let output = garden_capture(&[
+        "--config",
+        "tests/data/shell/custom.yaml",
+        "--define",
+        "garden.shell=zsh -o shwordsplit -c",
+        "--quiet",
+        "shell-words",
+    ]);
+    assert_eq!(output, "a\nb\nc");
+}
+
 /// Test the use of graft:: tree references in groups.
 #[test]
 fn cmd_exec_group_with_grafted_trees() {


### PR DESCRIPTION
garden.shell can not be configured to arbitrary interpreter commands.
We now run the value through the "shlex" parser to separate the
string into individual command-line arguments.
    
Shorthand shell values are still supported and special-cased.
Only when the command string expands to a command with multiple
arguments we treat the command like a custom shell and
disable the internal builtin arguments.
