### PR TITLE
variables: add GARDEN_CMD_QUIET and GARDEN_CMD_VERBOSE for use by commands

### DIFF
--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -54,6 +54,13 @@
   `.` so that the tree in the current directory is used when nothing is specified.
   ([#26](https://github.com/davvid/garden/pull/26))
 
+- Custom commands now have access to a `${GARDEN_CMD_VERBOSE}` and `${GARDEN_CMD_QUIET}`
+  variables which can be used to forward the `--verbose` and `--quiet` arguments
+  down into child `garden` invocations. `${GARDEN_CMD_VERBOSE}` uses the short `-v`
+  flag in the value to support the case where the verbose option is specified
+  multiples times to increase the verbosity level (e.g. `-vv`).
+  ([#27](https://github.com/davvid/garden/pull/27))
+
 
 ## v1.2.1
 

--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -270,6 +270,15 @@ when constructing values for variables, commands, and paths.
 * **TREE_NAME** -- Current tree name.
 * **TREE_PATH** -- Current tree path.
 
+### Variables for Custom Commands
+
+The following built-in variables are provided to make it easier to write custom commands
+that re-execute `garden`. These variables allow you to forward the user-specified
+`-vv` or `--quiet` options to child commands.
+
+* **GARDEN_CMD_QUIET** -- `--quiet` when `--quiet` is specified, empty otherwise.
+* **GARDEN_CMD_VERBOSE** -- `-v`, `-vv` etc. when verbosity is increased, empty otherwise.
+
 ## Environment Variables
 
 The "environment" block defines variables that are stored in the environment.

--- a/src/config/reader.rs
+++ b/src/config/reader.rs
@@ -136,6 +136,23 @@ fn parse_recursive(
         }
     }
 
+    // Provide GARDEN_CMD_QUIET and GARDEN_CMD_VERBOSE.
+    let quiet_string = if config.quiet { "--quiet" } else { "" }.to_string();
+    let verbose_string = if config.verbose > 0 {
+        // -v can be specified multiple times, e.g. "-vv".
+        format!("-{}", "v".repeat(config.verbose.into()))
+    } else {
+        string!("")
+    };
+    config.variables.insert(
+        string!(constants::GARDEN_CMD_QUIET),
+        model::Variable::new(quiet_string.clone(), Some(quiet_string)),
+    );
+    config.variables.insert(
+        string!(constants::GARDEN_CMD_VERBOSE),
+        model::Variable::new(verbose_string.clone(), Some(verbose_string)),
+    );
+
     // Variables are read early to make them available to config.eval_config_pathbuf_from_include().
     // Variables are reloaded after "includes" to give the current garden file the highest priority.
     if !get_variables_hashmap(&doc[constants::VARIABLES], &mut config.variables)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -62,6 +62,12 @@ pub const GARDEN: &str = "garden";
 /// environment variables for commands.
 pub const GARDENS: &str = "gardens";
 
+/// Builtin variable is either empty or contains the "--quiet" command-line option.
+pub const GARDEN_CMD_QUIET: &str = "GARDEN_CMD_QUIET";
+
+/// Builtin variable is either empty or contains the "-v" verbosity level command-line option.
+pub const GARDEN_CMD_VERBOSE: &str = "GARDEN_CMD_VERBOSE";
+
 /// The default "garden.yaml" configuration file.
 pub const GARDEN_CONFIG: &str = "garden.yaml";
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -502,6 +502,8 @@ pub struct Configuration {
     /// Variables defined on the command-line using "-D name=value" have the
     /// highest precedence and override variables defined by any configuration or tree.
     pub override_variables: VariableHashMap,
+    pub config_verbose: u8,
+    pub quiet: bool,
     pub verbose: u8,
     pub(crate) shell_exit_on_error: bool,
     pub(crate) shell_word_split: bool,
@@ -583,7 +585,9 @@ impl Configuration {
         if let Some(parent_id) = parent {
             self.set_parent(parent_id);
         }
-        self.verbose = config_verbose;
+        self.config_verbose = config_verbose;
+        self.quiet = app_context.options.quiet;
+        self.verbose = app_context.options.verbose;
 
         // Override the configured garden root
         if let Some(root_path) = root.map(|path| path.canonicalize().unwrap_or(path.clone())) {

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -44,7 +44,12 @@ fn variables() -> Result<()> {
     );
     let app_context = common::garden_context_from_string(&string)?;
     let config = app_context.get_root_config();
-    assert_eq!(3, config.variables.len());
+    assert_eq!(5, config.variables.len());
+    assert!(config.variables.contains_key("GARDEN_ROOT"));
+    assert!(config.variables.contains_key("GARDEN_CMD_QUIET"));
+    assert!(config.variables.contains_key("GARDEN_CMD_VERBOSE"));
+    assert!(config.variables.contains_key("foo"));
+    assert!(config.variables.contains_key("bar"));
 
     let root_var = config.variables.get("GARDEN_ROOT").context("GARDEN_ROOT")?;
     assert_eq!("/home/test/src", root_var.get_expr());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -610,6 +610,56 @@ fn eval_garden_root() {
     );
 }
 
+/// `garden eval` handles ${GARDEN_CMD_QUIET} and ${GARDEN_CMD_VERBOSE}.
+#[test]
+fn eval_builtin_command_variables() {
+    let expect = "";
+    let output = garden_capture(&[
+        "--config",
+        "tests/data/garden.yaml",
+        "eval",
+        "${GARDEN_CMD_VERBOSE}",
+    ]);
+    assert_eq!(output, expect);
+    // The --verbose flag uses the short "-v" option to allow for increasing verbositry.
+    let expect = "-v";
+    let output = garden_capture(&[
+        "--verbose",
+        "--config",
+        "tests/data/garden.yaml",
+        "eval",
+        "${GARDEN_CMD_VERBOSE}",
+    ]);
+    assert_eq!(output, expect);
+    let expect = "-vv";
+    let output = garden_capture(&[
+        "-vv",
+        "--config",
+        "tests/data/garden.yaml",
+        "eval",
+        "${GARDEN_CMD_VERBOSE}",
+    ]);
+    assert_eq!(output, expect);
+    // GARDEN_CMD_QUIET is empty unless "--quiet" is specified.
+    let expect = "";
+    let output = garden_capture(&[
+        "--config",
+        "tests/data/garden.yaml",
+        "eval",
+        "${GARDEN_CMD_QUIET}",
+    ]);
+    assert_eq!(output, expect);
+    let expect = "--quiet";
+    let output = garden_capture(&[
+        "--quiet",
+        "--config",
+        "tests/data/garden.yaml",
+        "eval",
+        "${GARDEN_CMD_QUIET}",
+    ]);
+    assert_eq!(output, expect);
+}
+
 /// `garden eval` evaluates overridden variables.
 #[test]
 fn eval_override_variables() {


### PR DESCRIPTION
Make it easy to pass-through the user-specified verbosity flags by providing a garden variable that is suitable for using in a command.

The "-v" flag can be specified multiple times so it is provided using the short "-vv" option when "--verbose --verbose" is specified.