### PR TITLE
dev: switch to yaml-rust2 instead of my yaml-rust-davvid fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
+
+[[package]]
 name = "assert_cmd"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,7 +414,7 @@ dependencies = [
  "thiserror",
  "which",
  "xdg",
- "yaml-rust-davvid",
+ "yaml-rust2",
  "yansi",
 ]
 
@@ -1026,11 +1032,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
-name = "yaml-rust-davvid"
-version = "0.6.0"
+name = "yaml-rust2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f8a17c9120b0ec12c1052f32937ff984e383f937b65515f872d4e0e23622c3"
+checksum = "777f823b2efee8266b47d35cc79ab1130250c2e4d5dbd3baf0bf3f776ea03a0a"
 dependencies = [
+ "arraydeque",
  "encoding",
  "hashlink",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ subprocess = "0.2.9"
 thiserror = "1.0.56"
 which = "5.0.0"
 xdg = "2.5.2"
-yaml-rust = { version = "0.6", package = "yaml-rust-davvid" }
+yaml-rust = { version = "0.7", package = "yaml-rust2" }
 yansi = "0.5.1"
 
 [dev-dependencies]

--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -5,24 +5,24 @@
 **Features**:
 
 - Custom commands can now specify an interpreter to use on a per-command basis.
-  If a command uses a shebang `#!` line then the command's text will be passed as the
-  next argument to the specified command. For example, using `#!python3 -c` as the
-  first line in a custom command will cause `python3 -c <command>` to be executed.
+If a command uses a shebang `#!` line then the command's text will be passed as the
+next argument to the specified command. For example, using `#!python3 -c` as the
+first line in a custom command will cause `python3 -c <command>` to be executed.
 
 - Trees can now use branches defined in separate remotes when configuring the
-  default branch to checkout. `garden grow` will now fetch the remote associated with the
-  configured branch switching branches in order to make this possible.
+default branch to checkout. `garden grow` will now fetch the remote associated with the
+configured branch switching branches in order to make this possible.
 
 - Trees can now use any upstream branch from any configured remote in the `branches` section.
-  Previously, branches associated with non-default remotes could not be created unless
-  they were fetched beforehand. `garden grow` will now fetch the associated remote
-  before creating the local branch.
+Previously, branches associated with non-default remotes could not be created unless
+they were fetched beforehand. `garden grow` will now fetch the associated remote
+before creating the local branch.
 
 **Development**:
 
 - `garden` can now be built on Windows. Symlink trees and the XDG base directory support
-  is UNIX-only and disabled on Windows.
-  ([#17](https://gitlab.com/garden-rs/garden/-/issues/17))
+is UNIX-only and disabled on Windows.
+([#17](https://gitlab.com/garden-rs/garden/-/issues/17))
 
 
 ## v1.3.0
@@ -32,61 +32,61 @@
 **Features**:
 
 - `garden eval` and garden expressions in general will now resolve variables defined
-  within `environment` blocks. Environment blocks were previously not considered when
-  resolving variables. Environment blocks are now resolved and checked for variables
-  when `${variable}` expressions do not find the variable in scopes with higher
-  precedence. The precedence order, from strongest to weakest, is the `variables`
-  block in a garden's scope, the `variables` block in a tree's scope, the
-  `variables` block in global configuration scope, the `environments` block in
-  a garden's scope, the `environments` block in a tree's scope, the
-  `environments` block in global configuration scope and, lastly, OS environment
-  variables. The first entry found is used when expanding variable expressions.
-  ([#23](https://github.com/davvid/garden/pull/23))
+within `environment` blocks. Environment blocks were previously not considered when
+resolving variables. Environment blocks are now resolved and checked for variables
+when `${variable}` expressions do not find the variable in scopes with higher
+precedence. The precedence order, from strongest to weakest, is the `variables`
+block in a garden's scope, the `variables` block in a tree's scope, the
+`variables` block in global configuration scope, the `environments` block in
+a garden's scope, the `environments` block in a tree's scope, the
+`environments` block in global configuration scope and, lastly, OS environment
+variables. The first entry found is used when expanding variable expressions.
+([#23](https://github.com/davvid/garden/pull/23))
 
 - Evaluation cycles (i.e. circular variable dependencies) are now prevented when
-  evaluating garden variables. The evaluation engine will now return empty strings
-  when a variable with a cyclical expression is evaluated.
-  ([#24](https://github.com/davvid/garden/pull/24))
+evaluating garden variables. The evaluation engine will now return empty strings
+when a variable with a cyclical expression is evaluated.
+([#24](https://github.com/davvid/garden/pull/24))
 
 - When `zsh` is used as the `garden.shell`, which happens automatically when `zsh`
-  is installed, `garden` will now use `zsh -o shwordsplit` in order to enable
-  word-splitting of `$variable` expressions by default. This makes `zsh` behave
-  just like other shells by default, which improves the portability of commands.
-  Configure `garden.shell-wordsplit` to `false` or use the
-  `garden <cmd> -z | --no-wordsplit` option to opt-out of this behavior.
-  ([#25](https://github.com/davvid/garden/pull/25))
+is installed, `garden` will now use `zsh -o shwordsplit` in order to enable
+word-splitting of `$variable` expressions by default. This makes `zsh` behave
+just like other shells by default, which improves the portability of commands.
+Configure `garden.shell-wordsplit` to `false` or use the
+`garden <cmd> -z | --no-wordsplit` option to opt-out of this behavior.
+([#25](https://github.com/davvid/garden/pull/25))
 
 - `garden.shell` can now be configured to use arbitrary commands for executing
-  command strings. Garden uses the configured `garden.shell` as-is and does
-  not augment its options (e.g. `-e`  or `-o shwordsplit`) when a custom command
-  is used. Custom commands are identified as commands that expand to 2 or more
-  command-line arguments. Thus, `python3` is not considered a custom command
-  and `garden` will run `python3 -c <string>` to run commands. On the other
-  hand, specifying `ruby -e` *is* considered a custom command because it
-  expands to `["ruby", "-e"]` under the hood. If you need to use a custom
-  command  that takes no additional command-line arguments then you can
-  use `env` as an extra argument to have it be considered as a custom shell.
-  For example, `env custom-shell` will cause `garden` to run
-  `env custom-shell <string>`, which is equivalent to `custom-shell <string>`.
-  Using just `custom-shell` would have resulted in `garden` running
-  `custom-shell -c <string>` instead, which may not be desired.
-  ([#26](https://github.com/davvid/garden/pull/26))
+command strings. Garden uses the configured `garden.shell` as-is and does
+not augment its options (e.g. `-e`  or `-o shwordsplit`) when a custom command
+is used. Custom commands are identified as commands that expand to 2 or more
+command-line arguments. Thus, `python3` is not considered a custom command
+and `garden` will run `python3 -c <string>` to run commands. On the other
+hand, specifying `ruby -e` *is* considered a custom command because it
+expands to `["ruby", "-e"]` under the hood. If you need to use a custom
+command  that takes no additional command-line arguments then you can
+use `env` as an extra argument to have it be considered as a custom shell.
+For example, `env custom-shell` will cause `garden` to run
+`env custom-shell <string>`, which is equivalent to `custom-shell <string>`.
+Using just `custom-shell` would have resulted in `garden` running
+`custom-shell -c <string>` instead, which may not be desired.
+([#26](https://github.com/davvid/garden/pull/26))
 
 - The `garden shell` command can now be configured to use an interactive command shell
-  that is distinct from the command specified in the `garden.shell` configuration by
-  configuring the `garden.interactive-shell` value.
-  ([#26](https://github.com/davvid/garden/pull/26))
+that is distinct from the command specified in the `garden.shell` configuration by
+configuring the `garden.interactive-shell` value.
+([#26](https://github.com/davvid/garden/pull/26))
 
 - `garden shell` can now be run without any arguments. The tree query now defaults to
-  `.` so that the tree in the current directory is used when nothing is specified.
-  ([#26](https://github.com/davvid/garden/pull/26))
+`.` so that the tree in the current directory is used when nothing is specified.
+([#26](https://github.com/davvid/garden/pull/26))
 
 - Custom commands now have access to a `${GARDEN_CMD_VERBOSE}` and `${GARDEN_CMD_QUIET}`
-  variables which can be used to forward the `--verbose` and `--quiet` arguments
-  down into child `garden` invocations. `${GARDEN_CMD_VERBOSE}` uses the short `-v`
-  flag in the value to support the case where the verbose option is specified
-  multiples times to increase the verbosity level (e.g. `-vv`).
-  ([#27](https://github.com/davvid/garden/pull/27))
+variables which can be used to forward the `--verbose` and `--quiet` arguments
+down into child `garden` invocations. `${GARDEN_CMD_VERBOSE}` uses the short `-v`
+flag in the value to support the case where the verbose option is specified
+multiples times to increase the verbosity level (e.g. `-vv`).
+([#27](https://github.com/davvid/garden/pull/27))
 
 
 ## v1.2.1
@@ -107,44 +107,44 @@
 **Features**:
 
 - If a garden file has no trees defined at all then an implicit tree called
-  `.` will now be synthesized into existence. The presence of this implicit tree
-  allows garden files that define just the current directory as a tree to omit
-  the entire `trees` section altogether. This consequently makes it easier
-  to use garden as a simple command runner because the `commands` section
-  is the only section required in order to run `garden` commands.
+`.` will now be synthesized into existence. The presence of this implicit tree
+allows garden files that define just the current directory as a tree to omit
+the entire `trees` section altogether. This consequently makes it easier
+to use garden as a simple command runner because the `commands` section
+is the only section required in order to run `garden` commands.
 
 - When `garden.root` is not configured `garden` will behave as if
-  `garden.root` is configured to `${GARDEN_CONFIG_DIR}`. This allows garden files to
-  omit `garden.root` from their configuration in typical scenarios.
+`garden.root` is configured to `${GARDEN_CONFIG_DIR}`. This allows garden files to
+omit `garden.root` from their configuration in typical scenarios.
 
 - Configuring `garden.root` to an empty string (`""`) will behave as if `garden.root`
-  is configured to the current directory from which `garden` was run.
+is configured to the current directory from which `garden` was run.
 
 - When a `garden.yaml` file does not exist in the current directory then garden
-  will walk up the file system searching for `garden.yaml` or the name specified using
-  `garden -c <name>`. Garden will behave as if it were launched from the directory
-  containing the garden file when a configuration file is found.
+will walk up the file system searching for `garden.yaml` or the name specified using
+`garden -c <name>`. Garden will behave as if it were launched from the directory
+containing the garden file when a configuration file is found.
 
 - The `GARDEN_CEILING_DIRS` and `GIT_CEILING_DIRS` environment variables can be
-  used to limit the `garden.yaml` discovery by preventing `garden` from traversing
-  into and beyond the specified directories when discovering garden files.
+used to limit the `garden.yaml` discovery by preventing `garden` from traversing
+into and beyond the specified directories when discovering garden files.
 
 - `garden exec`, `garden cmd` `garden grow`, `garden ls` and custom garden commands
-  can now filter the trees they operate over by passing a glob pattern using
-  `-t | --trees` option. These commands will only operate on the trees whose names
-  match the pattern. This allows you to specify a garden as the tree query and use
-  the full set of environment variables from all trees in the query while
-  executing commands over a subset of the trees in that garden.
+can now filter the trees they operate over by passing a glob pattern using
+`-t | --trees` option. These commands will only operate on the trees whose names
+match the pattern. This allows you to specify a garden as the tree query and use
+the full set of environment variables from all trees in the query while
+executing commands over a subset of the trees in that garden.
 
 - `garden init` will now add the current directory to the `trees` block
-  when the current directory contains a Git repository. Use `garden init --empty`
-  to disable this behavior.
+when the current directory contains a Git repository. Use `garden init --empty`
+to disable this behavior.
 
 **Development**:
 
 - The `shlex` dependency was upgraded to `1.3.0`, which includes fixes for
-  [RUSTSEC-2024-0006](https://rustsec.org/advisories/RUSTSEC-2024-0006.html) a.k.a.
-  [GHSA-r7qv-8r2h-pg27](https://github.com/comex/rust-shlex/security/advisories/GHSA-r7qv-8r2h-pg27).
+[RUSTSEC-2024-0006](https://rustsec.org/advisories/RUSTSEC-2024-0006.html) a.k.a.
+[GHSA-r7qv-8r2h-pg27](https://github.com/comex/rust-shlex/security/advisories/GHSA-r7qv-8r2h-pg27).
 
 ## v1.1.0
 
@@ -157,22 +157,22 @@
 - `garden ls -c` (i.e. `--no-commands`) hides command details from the output.
 
 - `garden plant -s` (i.e. `--sort`) sorts all of the configured `trees` entries
-  after planting the specified trees.
+after planting the specified trees.
 
 - `garden exec -n` (i.e. `--dry-run`) performs a trial run without executing
-  any commands.
+any commands.
 
 - `garden.shell-errexit` can now be configured to `false` in `garden.yaml` to
-  opt-out of using the `-e` exit-on-error shell option when running custom commands.
+opt-out of using the `-e` exit-on-error shell option when running custom commands.
 
 - `garden.shell` can now be configured to `bun`, `fish`, `node`, `perl` and `python3`
-  in addition to the traditional `bash`, `zsh`, `dash`, `ksh` and `sh` shells.
-  This allows you to use these interpreters to run custom commands.
+in addition to the traditional `bash`, `zsh`, `dash`, `ksh` and `sh` shells.
+This allows you to use these interpreters to run custom commands.
 
 **Development**:
 
 - Garden is now using
-  [shellexpand v3](https://gitlab.com/ijackson/rust-shellexpand#version-300-2022-12-01).
+[shellexpand v3](https://gitlab.com/ijackson/rust-shellexpand#version-300-2022-12-01).
 
 ## v1.0.0
 
@@ -181,23 +181,23 @@
 **Features**:
 
 - Commands can now specify pre-commands and post-commands that are run before/after
-  the specified command.
-  ([#3](https://github.com/davvid/garden/issues/3))
-  ([documentation](https://garden-rs.gitlab.io/commands.html#pre-and-post-commands))
+the specified command.
+([#3](https://github.com/davvid/garden/issues/3))
+([documentation](https://garden-rs.gitlab.io/commands.html#pre-and-post-commands))
 
 - The default `origin` remote name can now be configured using `tree.<tree>.default-remote`.
-  ([#16](https://gitlab.com/garden-rs/garden/-/issues/16))
+([#16](https://gitlab.com/garden-rs/garden/-/issues/16))
 
 - Commands now display the tree's current branch alongside the tree name.
-  ([#18](https://github.com/davvid/garden/issues/18))
+([#18](https://github.com/davvid/garden/issues/18))
 
 - `garden -vv exec` and `garden -vv shell` now display the command being run.
 
 **Packaging**:
 
 - `garden` can now be installed as a `nix flake` package.
-  A `flake.nix` file is now provided.
-  ([#16](https://github.com/davvid/garden/issues/16))
+A `flake.nix` file is now provided.
+([#16](https://github.com/davvid/garden/issues/16))
 
 ## v0.9.1
 
@@ -206,9 +206,9 @@
 **Fixes**:
 
 - `garden -D name=value` now overrides variables in all scopes.
-  Variables defined in tree scope were not subject to overrides and
-  will now get properly overridden by the `--define` / `-D`
-  command-line options.
+Variables defined in tree scope were not subject to overrides and
+will now get properly overridden by the `--define` / `-D`
+command-line options.
 
 ## v0.9.0
 
@@ -217,8 +217,8 @@
 **Features**:
 
 - `garden grow` now sets `git config remote.$name.tagopt --no-tags`
-  when adding additional remotes. This prevents accidentally fetching tags
-  when interacting with remotes.
+when adding additional remotes. This prevents accidentally fetching tags
+when interacting with remotes.
 
 ## v0.8.1
 
@@ -227,14 +227,14 @@
 **Fixes**:
 
 - `garden grow` was fixed to detect existing branches when growing
-  `git worktree`-created child worktrees.
+`git worktree`-created child worktrees.
 
 **Development**:
 
 - `strum` is now used to implement `FromStr` for `enum ColorMode`.
 
 - [is-terminal](https://crates.io/crates/is-terminal) is now used instead of
-  the unmaintained `atty` crate.
+the unmaintained `atty` crate.
 
 ## v0.8.0
 
@@ -250,7 +250,7 @@ referenced using `graft::` namespace qualifiers.
 - `garden grow` can now configure [upstream branches](https://garden-rs.gitlab.io/commands.html#upstream-branches).
 
 - `garden grow` can now configure [gitconfig settings with multiple values](https://garden-rs.gitlab.io/commands.html#upstream-branches#git-configuration-values)
-  using [`git config --add <name> <value>`](https://git-scm.com/docs/git-config#Documentation/git-config.txt---add).
+using [`git config --add <name> <value>`](https://git-scm.com/docs/git-config#Documentation/git-config.txt---add).
 
 ## v0.7.0
 
@@ -259,25 +259,25 @@ referenced using `graft::` namespace qualifiers.
 **Features**:
 
 - Trees, Groups, Gardens and Commands defined in the top-level `garden.yaml` can now
-  override entries defined via `garden.includes`. Configuration entities now follow
-  "last one wins" semantics -- if the same entity is defined in multiple includes files
-  then only the final definition will be used.
-  ([#14](https://github.com/davvid/garden/issues/14))
-  ([#15](https://github.com/davvid/garden/pull/15))
+override entries defined via `garden.includes`. Configuration entities now follow
+"last one wins" semantics -- if the same entity is defined in multiple includes files
+then only the final definition will be used.
+([#14](https://github.com/davvid/garden/issues/14))
+([#15](https://github.com/davvid/garden/pull/15))
 
 - [Trees now sparsely override existing entries](https://garden-rs.gitlab.io/configuration.html#l#the-last-one-wins-rule).
-  This behavior allows a tree definition to replace just the `url` field, or to replace
-  individual tree commands while retaining the rest. Use `replace: true` in a Tree
-  definition in order to completely replace the existing entry instead of sparsely
-  overriding it.
+This behavior allows a tree definition to replace just the `url` field, or to replace
+individual tree commands while retaining the rest. Use `replace: true` in a Tree
+definition in order to completely replace the existing entry instead of sparsely
+overriding it.
 
 - Improved shell completions for `garden`, `garden init` and `garden plant`.
 
 **Packaging**:
 
 - [0323pin](https://github.com/0323) packaged `garden` for pkgsrc/NetBSD and
-  [merged the package into the main branch!](http://mail-index.netbsd.org/pkgsrc-changes/2023/01/22/msg267560.html)
-  ([#13](https://github.com/davvid/garden/issues/13))
+[merged the package into the main branch!](http://mail-index.netbsd.org/pkgsrc-changes/2023/01/22/msg267560.html)
+([#13](https://github.com/davvid/garden/issues/13))
 
 ## v0.6.0
 
@@ -286,14 +286,14 @@ referenced using `graft::` namespace qualifiers.
 **Features**:
 
 - Both names and values in `gitconfig` can now use `${var}` expressions.
-  Previously only values were evaluated. Names are evaluated now as well.
+Previously only values were evaluated. Names are evaluated now as well.
 
 **Fixes**:
 
 - The `zsh` workaround for `garden completion zsh` is no longer needed.
-  The [documentation for generating zsh completions](https://garden-rs.gitlab.io/commands.html#zsh)
-  has been updated.
-  ([#10](https://github.com/davvid/garden/issues/10))
+The [documentation for generating zsh completions](https://garden-rs.gitlab.io/commands.html#zsh)
+has been updated.
+([#10](https://github.com/davvid/garden/issues/10))
 
 ## v0.5.1
 
@@ -302,8 +302,8 @@ referenced using `graft::` namespace qualifiers.
 **Fixes**:
 
 - Exec expressions were previously run with the current directory set to the
-  directory from which garden was run. Exec expressions are now run in the
-  tree's current directory.
+directory from which garden was run. Exec expressions are now run in the
+tree's current directory.
 
 ## v0.5.0
 
@@ -312,41 +312,41 @@ referenced using `graft::` namespace qualifiers.
 **Features**:
 
 - [Garden configuration files can now include other configuration files
-  ](https://garden-rs.gitlab.io/configuration.html#includes) by specifying
-  the additional files to include in the `garden.includes` field.
-  The `includes` feature makes it possible to create modular and reusable garden files.
-  The `trees`, `variables`, `commands`, `groups` and `gardens` defined in the included
-  files are added to the current configuration.
-  ([#7](https://github.com/davvid/garden/pull/7))
+](https://garden-rs.gitlab.io/configuration.html#includes) by specifying
+the additional files to include in the `garden.includes` field.
+The `includes` feature makes it possible to create modular and reusable garden files.
+The `trees`, `variables`, `commands`, `groups` and `gardens` defined in the included
+files are added to the current configuration.
+([#7](https://github.com/davvid/garden/pull/7))
 
 - [Garden commands can now use shell variables](https://garden-rs.gitlab.io/commands.html#shell-syntax)
-  using the standard (brace-less) shell `$variable` syntax. The braced `${garden}`
-  variable syntax remains reserved for resolving Garden Variables.
-  Double-`$` braces (ex: `$${...}`) can be used to escape a `$${variable}` from
-  evaluation so that a literal `${variable}` value is used in the garden command.
-  ([#11](https://github.com/davvid/garden/issues/11))
-  ([#12](https://github.com/davvid/garden/pull/12))
+using the standard (brace-less) shell `$variable` syntax. The braced `${garden}`
+variable syntax remains reserved for resolving Garden Variables.
+Double-`$` braces (ex: `$${...}`) can be used to escape a `$${variable}` from
+evaluation so that a literal `${variable}` value is used in the garden command.
+([#11](https://github.com/davvid/garden/issues/11))
+([#12](https://github.com/davvid/garden/pull/12))
 
 - A new `garden completion` subcommand was added for providing shell command-line
-  completion using the [clap_complete](https://crates.io/crates/clap_complete) crate.
-  ([#9](https://github.com/davvid/garden/pull/9))
+completion using the [clap_complete](https://crates.io/crates/clap_complete) crate.
+([#9](https://github.com/davvid/garden/pull/9))
 
 - `garden -V | --version` was added alongside the `clap` rewrite for displaying
-  the `garden` command version.
+the `garden` command version.
 
 **Development**:
 
 - The `Makefile` has been replaced by a `garden.yaml` Garden file.
-  We can now use `garden {build, test, check, fmt, clippy, ...}` instead of `make ...`.
-  See [garden.yaml @ 5ef8d0ab16 for more details](https://gitlab.com/garden-rs/garden/-/raw/5ef8d0ab16a64660fef2bfc551e69cc782dfd4a3/garden.yaml).
-  Packagers can use `cargo install` to install `garden` and invoke `mdbook` directly
-  to install the user manual. We also provide
-  `garden -D DESTDIR=/tmp/stage -D prefix=/usr/local install-doc` if distros
-  want to install the user manual using our recipe.
-  ([#8](https://github.com/davvid/garden/pull/8))
+We can now use `garden {build, test, check, fmt, clippy, ...}` instead of `make ...`.
+See [garden.yaml @ 5ef8d0ab16 for more details](https://gitlab.com/garden-rs/garden/-/raw/5ef8d0ab16a64660fef2bfc551e69cc782dfd4a3/garden.yaml).
+Packagers can use `cargo install` to install `garden` and invoke `mdbook` directly
+to install the user manual. We also provide
+`garden -D DESTDIR=/tmp/stage -D prefix=/usr/local install-doc` if distros
+want to install the user manual using our recipe.
+([#8](https://github.com/davvid/garden/pull/8))
 
 - Garden's command-line parsing has been rewritten to leverage the
-  [clap](https://crates.io/crates/clap) crate and ecosystem.
+[clap](https://crates.io/crates/clap) crate and ecosystem.
 
 ## v0.4.1
 
@@ -355,8 +355,8 @@ referenced using `graft::` namespace qualifiers.
 **Features**:
 
 - The `garden cmd --no-errexit` option was extended to work with commands that are
-  configured using a YAML list of strings. Commands that are specified using lists
-  are now indistinguishable from commands specified using multi-line strings.
+configured using a YAML list of strings. Commands that are specified using lists
+are now indistinguishable from commands specified using multi-line strings.
 
 ## v0.4.0
 
@@ -365,26 +365,26 @@ referenced using `graft::` namespace qualifiers.
 **Breaking Changes**:
 
 - `garden cmd` now runs custom commands using `<shell> -e -c '<command>'` by default.
-  The use of `-e` is a change in behavior and causes multi-line / multi-statement
-  commands to halt execution when the first non-zero exit code is encountered.
-  Use `set +e` at the top of of a multi-line command to opt-out of this behavior
-  on a per-command basis, or specify the `-n | --no-errexit` option.
+The use of `-e` is a change in behavior and causes multi-line / multi-statement
+commands to halt execution when the first non-zero exit code is encountered.
+Use `set +e` at the top of of a multi-line command to opt-out of this behavior
+on a per-command basis, or specify the `-n | --no-errexit` option.
 
 - `garden` will now fallback to `bash` (and `sh`) as the default `garden.shell` value
-  when `zsh` (and `bash`) are not installed. As before, the `garden.shell`
-  configuration variable can be used to override the default shell.
+when `zsh` (and `bash`) are not installed. As before, the `garden.shell`
+configuration variable can be used to override the default shell.
 
 **Features**:
 
 - `garden prune` was added for removing orphaned Git repositories.
-  ([#4](https://github.com/davvid/garden/issues/4))
+([#4](https://github.com/davvid/garden/issues/4))
 
 - `garden cmd` can now run commands in breadth-first order when the
-  `-b/--breadth-first` option is used. Depth-first tree traversal is the default.
-  The `garden cmd --breadth-first` traversal runs all commands on a tree before
-  continuing on to the next tree. The default `garden cmd` depth-first traversal
-  runs a command across all trees before continuing on to the next command.
-  ([#3](https://github.com/davvid/garden/issues/3))
+`-b/--breadth-first` option is used. Depth-first tree traversal is the default.
+The `garden cmd --breadth-first` traversal runs all commands on a tree before
+continuing on to the next tree. The default `garden cmd` depth-first traversal
+runs a command across all trees before continuing on to the next command.
+([#3](https://github.com/davvid/garden/issues/3))
 
 ## v0.3.0
 
@@ -393,7 +393,7 @@ referenced using `graft::` namespace qualifiers.
 **Features**:
 
 - `garden plant` can now detect `git worktree` repositories.
-  ([#1](https://github.com/davvid/garden/issues/1))
+([#1](https://github.com/davvid/garden/issues/1))
 
 ## v0.2.0
 

--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -24,6 +24,10 @@ before creating the local branch.
 is UNIX-only and disabled on Windows.
 ([#17](https://gitlab.com/garden-rs/garden/-/issues/17))
 
+- [yaml-rust2](https://crates.io/crates/yaml-rust2) is now used instead of
+the [yaml-rust-davvid](https://crates.io/crates/yaml-rust-davvid) fork that was
+being maintained by [@davvid](https://github.com/davvid) for use by garden.
+
 
 ## v1.3.0
 


### PR DESCRIPTION
My davvid/yaml-rust fork at https://github.com/davvid/yaml-rust
and https://crates.io/crates/yaml-rust-davvid has been
merged into yaml-rust2.
    
- https://github.com/Ethiraric/yaml-rust2
- https://crates.io/crates/yaml-rust2