### PR TITLE
cmds: make "--verbose" cumulative when specified to sub-commands

### DIFF
--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -12,13 +12,14 @@
   The zsh `nomatch` option is a less useful option for non-interactive use
   so we disable it unconditionally.
 
-- The `--verbose` (`-v`) option can now be passed to custom commands.
+- The `--verbose` (`-v`) option can now be passed to custom and built-in commands.
 The `verbose` option was previously a global option that had to
 be specified before sub-commands. The following invocations are all
 equivalent now:
   - `garden -vv build`
   - `garden -v build -v`
   - `garden build -vv`
+([#36](https://github.com/garden-rs/garden/-/pull/36))
 
 
 ## v1.5.0

--- a/doc/src/changelog.md
+++ b/doc/src/changelog.md
@@ -12,6 +12,15 @@
   The zsh `nomatch` option is a less useful option for non-interactive use
   so we disable it unconditionally.
 
+- The `--verbose` (`-v`) option can now be passed to custom commands.
+The `verbose` option was previously a global option that had to
+be specified before sub-commands. The following invocations are all
+equivalent now:
+  - `garden -vv build`
+  - `garden -v build -v`
+  - `garden build -vv`
+
+
 ## v1.5.0
 
 *Released 2024-04-14*

--- a/src/cmds/cmd.rs
+++ b/src/cmds/cmd.rs
@@ -29,6 +29,9 @@ pub struct CmdOptions {
     /// Run commands even when the tree does not exist.
     #[arg(long, short)]
     force: bool,
+    /// Increase verbosity level (default: 0)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
     /// Do not pass "-o shwordsplit" to zsh.
     /// Prevent the "shwordsplit" shell option from being set when using zsh.
     /// The "-o shwordsplit" option is passed to zsh by default so that unquoted
@@ -70,6 +73,9 @@ pub struct CustomOptions {
     /// Run commands even when the tree does not exist.
     #[arg(long, short)]
     force: bool,
+    /// Increase verbosity level (default: 0)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
     /// Do not pass "-o shwordsplit" to zsh.
     /// Prevent the "shwordsplit" shell option from being set when using zsh.
     /// The "-o shwordsplit" option is passed to zsh by default so that unquoted
@@ -122,6 +128,7 @@ pub struct CmdParams {
     keep_going: bool,
     #[derivative(Default(value = "true"))]
     exit_on_error: bool,
+    verbose: u8,
     #[derivative(Default(value = "true"))]
     word_split: bool,
 }
@@ -137,6 +144,7 @@ impl From<CmdOptions> for CmdParams {
             force: options.force,
             keep_going: options.keep_going,
             tree_pattern: glob::Pattern::new(&options.trees).unwrap_or_default(),
+            verbose: options.verbose,
             word_split: options.word_split,
             ..Default::default()
         }
@@ -159,6 +167,7 @@ impl From<CustomOptions> for CmdParams {
             exit_on_error: options.exit_on_error,
             force: options.force,
             tree_pattern: glob::Pattern::new(&options.trees).unwrap_or_default(),
+            verbose: options.verbose,
             word_split: options.word_split,
             ..Default::default()
         };
@@ -247,7 +256,7 @@ fn run_cmd_breadth_first(
 ) -> Result<i32> {
     let mut exit_status: i32 = errors::EX_OK;
     let quiet = app_context.options.quiet;
-    let verbose = app_context.options.verbose;
+    let verbose = app_context.options.verbose + params.verbose;
     let shell = app_context.get_root_config().shell.as_str();
     let shell_params = ShellParams::new(shell, params.exit_on_error, params.word_split);
     // Loop over each command, evaluate the tree environment,
@@ -394,7 +403,7 @@ fn run_cmd_depth_first(
 ) -> Result<i32> {
     let mut exit_status: i32 = errors::EX_OK;
     let quiet = app_context.options.quiet;
-    let verbose = app_context.options.verbose;
+    let verbose = app_context.options.verbose + params.verbose;
     let shell = app_context.get_root_config().shell.as_str();
     let shell_params = ShellParams::new(shell, params.exit_on_error, params.word_split);
     // Loop over each context, evaluate the tree environment and run the command.

--- a/src/cmds/exec.rs
+++ b/src/cmds/exec.rs
@@ -13,6 +13,9 @@ pub struct ExecOptions {
     /// Perform a trial run without executing any commands
     #[arg(long, short = 'n')]
     dry_run: bool,
+    /// Increase verbosity level (default: 0)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
     /// Tree query for the gardens, groups or trees to run the command
     #[arg(value_hint=ValueHint::Other)]
     query: String,
@@ -39,7 +42,7 @@ fn exec(
     exec_options: &ExecOptions,
 ) -> Result<()> {
     let quiet = app_context.options.quiet;
-    let verbose = app_context.options.verbose;
+    let verbose = app_context.options.verbose + exec_options.verbose;
     let dry_run = exec_options.dry_run;
     let query = &exec_options.query;
     let tree_pattern = &exec_options.trees;

--- a/src/cmds/grow.rs
+++ b/src/cmds/grow.rs
@@ -12,6 +12,9 @@ type GitConfigMap = HashMap<String, HashSet<String>>;
 #[derive(Parser, Clone, Debug)]
 #[command(author, about, long_about)]
 pub struct GrowOptions {
+    /// Increase verbosity level (default: 0)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
     /// Filter trees by name post-query using a glob pattern
     #[arg(long, short, default_value = "*")]
     trees: String,
@@ -23,7 +26,7 @@ pub struct GrowOptions {
 /// Main entry point for the "garden grow" command
 pub fn main(app_context: &model::ApplicationContext, options: &GrowOptions) -> Result<()> {
     let quiet = app_context.options.quiet;
-    let verbose = app_context.options.verbose;
+    let verbose = app_context.options.verbose + options.verbose;
     let mut exit_status = errors::EX_OK;
     let mut configured_worktrees: HashSet<String> = HashSet::new();
     for query in &options.queries {

--- a/src/cmds/list.rs
+++ b/src/cmds/list.rs
@@ -13,6 +13,9 @@ pub struct ListOptions {
     /// Do not list commands
     #[arg(long, short = 'c', default_value_t = false)]
     no_commands: bool,
+    /// Increase verbosity level (default: 0)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
     /// Display worktrees
     #[arg(short, long, default_value_t = false)]
     worktrees: bool,
@@ -37,7 +40,7 @@ fn list(app_context: &model::ApplicationContext, options: &ListOptions) -> Resul
     let display_all = options.all;
     let display_worktrees = options.worktrees;
     let show_commands = !options.no_commands;
-    let verbose = app_context.options.verbose;
+    let verbose = app_context.options.verbose + options.verbose;
     let mut needs_newline = false;
 
     if app_context.options.debug_level(constants::DEBUG_LEVEL_LIST) > 0 {

--- a/src/cmds/plant.rs
+++ b/src/cmds/plant.rs
@@ -14,6 +14,9 @@ pub struct PlantOptions {
     /// Sort all trees after planting new trees
     #[arg(long, short)]
     sort: bool,
+    /// Increase verbosity level (default: 0)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
     /// Trees to plant
     #[arg(required = true, value_hint=ValueHint::DirPath)]
     paths: Vec<String>,
@@ -21,7 +24,7 @@ pub struct PlantOptions {
 
 pub fn main(app_context: &model::ApplicationContext, options: &PlantOptions) -> Result<()> {
     // Read existing configuration
-    let verbose = app_context.options.verbose;
+    let verbose = app_context.options.verbose + options.verbose;
     let config = app_context.get_root_config();
     let mut doc = config::reader::read_yaml(config.get_path()?)?;
 

--- a/src/cmds/shell.rs
+++ b/src/cmds/shell.rs
@@ -7,6 +7,9 @@ use crate::{cmd, errors, eval, model, query};
 #[derive(Parser, Clone, Debug)]
 #[command(author, about, long_about)]
 pub struct ShellOptions {
+    /// Increase verbosity level (default: 0)
+    #[arg(short, long, action = clap::ArgAction::Count)]
+    verbose: u8,
     /// Query for trees to build an environment
     #[arg(default_value = ".")]
     query: String,
@@ -69,7 +72,7 @@ pub fn main(app_context: &model::ApplicationContext, options: &ShellOptions) -> 
         context.garden.as_ref(),
     );
 
-    let verbose = app_context.options.verbose;
+    let verbose = app_context.options.verbose + options.verbose;
     let quiet = verbose == 0;
     if let Some(value) = shlex::split(&shell) {
         cmd::exec_in_context(


### PR DESCRIPTION
The "verbose" option was previously a global option that could only be
specified before the sub-command name.
    
Add "--verbose" to sub-commands so that we can enable verbosity directly
without needing to place the option in the right place.